### PR TITLE
Add support for EditorsKit navigator toolbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+**/node_modules/**

--- a/dist/blocks.editor.build.css
+++ b/dist/blocks.editor.build.css
@@ -1,7 +1,1911 @@
-.editor-block-list__block[data-type="kadence/spacer"].is-selected .editor-block-list__block-edit .kadence-spacer__resize-handler-top,.editor-block-list__block[data-type="kadence/spacer"].is-selected .editor-block-list__block-edit .kadence-spacer__resize-handler-bottom{display:block}.kt-inspect-tabs.kt-spacer-tabs .components-tab-panel__tabs{margin-bottom:10px}.kadence-spacer__resize-handler-top,.kadence-spacer__resize-handler-bottom{display:none;border-radius:50%;border:2px solid white;width:15px !important;height:15px !important;position:absolute;background:#0085ba;padding:0 3px 3px 0;cursor:se-resize;left:50% !important;margin-left:-7.5px}.kt-spacer-height-preview{display:-ms-flexbox;display:flex;width:100%;height:100%;-ms-flex-pack:center;justify-content:center;-ms-flex-align:center;align-items:center;color:#777;opacity:0;-webkit-transition:opacity .3s ease;-o-transition:opacity .3s ease;transition:opacity .3s ease}.kt-spacer-height-preview span{background:rgba(255,255,255,0.7);padding:0 6px}.is-selected .kt-block-spacer:hover .kt-spacer-height-preview{opacity:1}.kt-block-spacer{position:relative;height:100%;border:dashed 1px #eee}.kt-block-spacer .kt-divider{width:100%;border-top:solid 1px #eee;position:absolute;top:50%;margin:0;padding:0;border-bottom:0;border-left:0;border-right:0;left:50%;-webkit-transform:perspective(1px) translate(-50%, -50%);transform:perspective(1px) translate(-50%, -50%)}.kt-block-spacer.kt-block-spacer-halign-left .kt-divider{left:0;-webkit-transform:perspective(1px) translate(0%, -50%);transform:perspective(1px) translate(0%, -50%)}.kt-block-spacer.kt-block-spacer-halign-right .kt-divider{left:auto;right:0;-webkit-transform:perspective(1px) translate(0%, -50%);transform:perspective(1px) translate(0%, -50%)}
-.kt-button-text.is-selected{min-width:5px}.block-editor-rich-text__editable.kt-button-text [data-rich-text-placeholder]:after{display:inline-block}.block-editor-rich-text__editable.kt-button-text.is-selected:focus [data-rich-text-placeholder]:after{display:none}.kt-block-defaults-modal h2.kt-beside-btn-group,.kt-block-defaults-modal h2.kt-beside-color-label{font-size:14px;color:#555d66}.kt-block-defaults-modal h2.kt-tab-wrap-title.kt-color-settings-title{text-align:center;background:#f2f2f2;margin-bottom:0;font-size:14px;color:#555d66}.kt-btn-link-group .kt-btn-link-input input[type=text]{max-width:97%;width:100%}.kt-btn-link-group{display:-ms-flexbox;display:flex;max-width:100%}.edit-post-sidebar h2.side-h2-label{margin-bottom:4px}.kt-inspect-tabs .kt-btn-size-settings-container .kt-button-size-type-options{margin-bottom:0}.kt-btn-size-settings-container .kt-button-size-type-options{margin-bottom:0}.kt-box-shadow-label .components-base-control.components-toggle-control,.kt-box-shadow-label .components-toggle-control .components-base-control__field{margin-bottom:0 !important}.kt-box-shadow-label h2.kt-beside-color-label{-ms-flex-positive:1;flex-grow:1;margin:12px 0}.kt-box-shadow-label{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center}.kt-select-icon-container .rfip{margin:0 0 15px 0}.kt-inner-sub-section-row{display:-ms-flexbox;display:flex;margin-bottom:10px}.kt-box-shadow-subset{padding:0 2px;text-align:center}.kt-box-shadow-subset .kt-box-shadow-title{font-size:12px}.kt-box-shadow-subset .kt-advanced-color-settings-container{-ms-flex-direction:column-reverse;flex-direction:column-reverse}.edit-post-sidebar h2.kt-tab-wrap-title.kt-color-settings-title{text-align:center;background:#f2f2f2;margin-bottom:0}.kt-advanced-color-settings-container .kt-has-alpha{background-image:-webkit-linear-gradient(45deg, #ddd 25%, transparent 0),-webkit-linear-gradient(135deg, #ddd 25%, transparent 0),-webkit-linear-gradient(45deg, transparent 75%, #ddd 0),-webkit-linear-gradient(135deg, transparent 75%, #ddd 0);background-image:-o-linear-gradient(45deg, #ddd 25%, transparent 0),-o-linear-gradient(135deg, #ddd 25%, transparent 0),-o-linear-gradient(45deg, transparent 75%, #ddd 0),-o-linear-gradient(135deg, transparent 75%, #ddd 0);background-image:linear-gradient(45deg, #ddd 25%, transparent 0),linear-gradient(-45deg, #ddd 25%, transparent 0),linear-gradient(45deg, transparent 75%, #ddd 0),linear-gradient(-45deg, transparent 75%, #ddd 0);background-size:10px 10px;background-position:0 0,0 5px,5px -5px,-5px 0}.kt-advanced-color-settings-container .kt-color-icon-indicate{position:relative;-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1);-webkit-transition:-webkit-transform .1s ease;transition:-webkit-transform .1s ease;-o-transition:transform .1s ease;transition:transform .1s ease;transition:transform .1s ease, -webkit-transform .1s ease;border-radius:50%;padding:0}.kt-advanced-color-settings-container .kt-color-icon-indicate:hover{-webkit-transform:scale(1.2);-ms-transform:scale(1.2);transform:scale(1.2)}.components-popover__content .components-range-control.kt-opacity-value{padding:0 12px 12px}.components-popover__content .components-range-control.kt-opacity-value .components-base-control__field{-ms-flex-wrap:nowrap;flex-wrap:nowrap}.components-popover__content .components-range-control.kt-opacity-value .components-range-control__slider{-ms-flex-positive:10;flex-grow:10}.components-popover__content .components-range-control.kt-opacity-value .components-base-control__label{width:auto;margin-right:5px}.kt-advanced-color-settings-container .components-color-palette__clear svg{width:16px}.kt-advanced-color-settings-container .components-color-palette__clear{background:transparent;padding:4px;height:auto;-webkit-box-shadow:none;box-shadow:none;border:1px solid transparent}.kt-beside-color-click{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center}.kt-advanced-color-settings-container .kt-color-icon-indicate .component-color-indicator.kt-advanced-color-indicate{width:28px;height:28px;border-radius:50%;margin:0}.components-popover__content .components-color-palette .components-color-palette__item-wrapper{margin-right:5px;margin-bottom:10px;margin-left:5px}.components-popover__content .components-color-palette .components-color-palette__item-wrapper:last-child{margin-right:0}.components-popover__content .components-color-palette{margin:0;padding:0px 12px 12px;width:100%}.kt-advanced-color-settings-container{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center}.kt-advanced-color-settings-container h2.kt-beside-color-label{-ms-flex-positive:1;flex-grow:1}.kt-link-settings{border:1px solid #8d96a0;margin:2px 0;height:30px;padding:2px 8px}.kt-inner-sub-section{border:1px solid #ddd;border-top:0;padding:25px 10px 10px 10px;margin-bottom:15px;margin-top:-15px}.kt-inner-sub-section .kt-size-tabs .components-tab-panel__tabs{margin-bottom:10px}.kt-btn-size-settings-container .kt-beside-btn-group{-ms-flex-positive:1;flex-grow:1;margin:0}.btn-text-size-range{margin-top:8px}.edit-post-sidebar h2.kt-heading-size-title.kt-secondary-color-size{margin-top:0;font-weight:normal}.kt-btn-size-settings-container{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;margin:20px 0}.kt-link-settings .dashicon{width:16px;height:16px}.kt-button-size-type-options .dashicon{width:14px}.components-base-control__field .components-range-control__slider+.dashicon.dashicons-editor-textcolor{width:30px;height:30px}.kt-popover-container{float:left;margin-top:-20px}.components-popover.kt-popover-opacity .components-popover__content{padding:10px}.components-popover.kt-popover-opacity .components-popover__content .components-base-control .components-base-control__field{margin:0}.kt-popover-container .components-button.is-button{background:transparent;height:20px;padding:0;width:20px;border:0;-webkit-box-shadow:none !important;box-shadow:none !important}.kt-popover-container .components-button.is-button svg{opacity:1;-webkit-transition:all .3s ease-in-out;-o-transition:all .3s ease-in-out;transition:all .3s ease-in-out}.kt-popover-container .components-button.is-button:hover svg{opacity:0.7}.wp-block-kadence-advancedbtn form.blocks-button__inline-link{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;font-size:13px;line-height:1.4;width:340px}.components-panel__body.kt-font-family-area.is-opened{min-height:340px}.kt-color-indicate{display:block;float:right;margin-bottom:-18px;margin-top:10px}.components-panel__body.kt-font-family-area h2.kt-heading-fontfamily-title{margin-top:0}.wp-block-kadence-advancedbtn .btn-area-wrap form.blocks-button__inline-link{position:absolute;left:50%;top:100%;border:1px solid #eee;padding:0;background:white;-webkit-transform:translate(-50%, 0);-ms-transform:translate(-50%, 0);transform:translate(-50%, 0)}.kt-hover-tabs{padding-top:0;margin-top:-5px}.kt-hover-tabs .components-tab-panel__tabs{margin-bottom:15px}.kt-hover-tabs .components-tab-panel__tabs button.active-tab{border-color:#0085ba;color:#0085ba}.kt-hover-tabs .components-tab-panel__tabs button{background:transparent;border:0;border:1px solid #eee;border-bottom:4px solid transparent;padding:6px 16px;margin-bottom:-4px;outline:0;color:#575757;width:50%;font-size:14px;font-weight:bold}.wp-block-kadence-advancedbtn.kt-btn-align-left .btn-area-wrap form.blocks-button__inline-link{left:0;-webkit-transform:translate(0, 0);-ms-transform:translate(0, 0);transform:translate(0, 0)}.wp-block-kadence-advancedbtn.kt-btn-align-right .btn-area-wrap form.blocks-button__inline-link{left:auto;right:0;-webkit-transform:translate(0, 0);-ms-transform:translate(0, 0);transform:translate(0, 0)}.wp-block-kadence-advancedbtn .btn-area-wrap{position:relative;display:inline-block}[data-type="kadence/advancedbtn"].is-selected .wp-block-kadence-advancedbtn,[data-type="kadence/advancedbtn"].is-typing .wp-block-kadence-advancedbtn{padding-bottom:40px}.kt-button{z-index:1;position:relative;padding:8px 16px;cursor:pointer;font-size:18px;border-width:2px;border-radius:3px;border-color:#555555;background:transparent;color:#555555;display:-ms-flexbox;display:flex;text-align:center;-ms-flex-pack:center;justify-content:center;border-style:solid;overflow:hidden;-webkit-transition:all .3s ease-in-out;-o-transition:all .3s ease-in-out;transition:all .3s ease-in-out}.kt-button::before{position:absolute;content:"";top:0;right:0;bottom:0;left:0;z-index:-1;opacity:0;background:#444444;-webkit-transition:all .3s ease-in-out;-o-transition:all .3s ease-in-out;transition:all .3s ease-in-out}.kt-button:hover{border-color:#444444;color:#ffffff}.kt-button:hover::before{opacity:1}.kt-btn-size-small{font-size:16px;padding:4px 8px;border-width:1px}.kt-btn-size-large{font-size:20px;padding:12px 24px;border-width:3px}.kt-btn-svg-icon.kt-btn-side-right{padding-left:5px}.kt-btn-svg-icon.kt-btn-side-left{padding-right:5px}.kt-button-wrap{display:inline-block;margin-bottom:5px}.kt-btn-align-center{text-align:center}.kt-btn-align-left{text-align:left}.kt-btn-align-right{text-align:right}.wp-block-kadence-advancedbtn .btn-area-wrap:last-child{margin-right:0}.wp-block-kadence-advancedbtn .btn-area-wrap{margin-right:5px}.kt-force-btn-fullwidth .btn-inner-wrap>div{display:-ms-flexbox;display:flex}.wp-block-kadence-advancedbtn.kt-force-btn-fullwidth .btn-area-wrap{display:block;-ms-flex-positive:1;flex-grow:1}.wp-block-kadence-advancedbtn.kt-force-btn-fullwidth .btn-area-wrap .kt-button-wrap{display:block}.wp-block-kadence-advancedbtn.kt-force-btn-fullwidth .kt-button{-ms-flex-pack:center;justify-content:center}
-.wp-block-kadence-rowlayout .kb-blocks-bg-slider,.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slider{position:absolute;left:0;right:0;top:0;bottom:0;padding:0}.wp-block-kadence-rowlayout .kb-blocks-bg-slider{top:-16px;bottom:-16px}.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-track,.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-list,.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slide{height:100%}.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slide div.kb-bg-slide{background-position:center;background-size:cover}.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-dots{bottom:0}.kb-blocks-bg-slider>.kb-bg-slide-contain,.kb-blocks-bg-slider>.kb-bg-slide-contain .kb-bg-slide{top:0;bottom:0;left:0;right:0;position:absolute}.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slide div{position:relative;height:100%}.kb-blocks-bg-video-container{right:0;left:0;top:-16px;bottom:-16px;position:absolute;overflow:hidden}.kb-blocks-bg-video{-o-object-position:50% 50%;object-position:50% 50%;-o-object-fit:cover;object-fit:cover;background-position:center center;width:100%;height:100%}div.kb-blocks-bg-video{background-repeat:no-repeat;background-size:cover}.edit-post-settings-sidebar__panel-block .kt-inspect-tabs .components-panel__body:last-child{margin-bottom:0}button.components-button.kb-sidebar-image{width:150px;height:40px;margin-right:5px;background-position:center;color:white;text-shadow:1px 1px 1px #000}.kt-sidebar-settings-spacer{height:15px;border-top:1px solid #e2e4e7;margin:0 -16px;background:#f9f9f9}.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs button:focus{-webkit-box-shadow:0;box-shadow:0;border:0}.kt-inner-column-height-full .kadence-inner-column-inner:before{display:table;clear:both;content:''}.kt-inner-column-height-full .kadence-inner-column-inner{height:100%}.kt-inner-column-height-full .editor-block-list__layout .editor-block-list__block[data-type="kadence/column"]>.editor-block-list__block-edit>div[data-block]{height:100%;display:-ms-flexbox;display:flex;margin:0;padding-top:28px;padding-bottom:28px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-30px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:-25px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:5px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-25px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:-20px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:0px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-22px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:-17px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:-3px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-18px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:-13px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:-7px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-12px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:-7px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:-13px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-8px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:-3px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:-17px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-5px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:0px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:-20px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:0px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn{right:5px}.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size{margin-left:-25px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-40px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn{right:-35px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size{margin-left:15px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right,.wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-35px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn,.wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size,.wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn{right:-30px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size,.wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size{margin-left:10px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-30px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn{right:-25px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size{margin-left:5px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-25px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn{right:-20px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size{margin-left:0px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right{margin-right:-20px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size,.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn{right:-15px}.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size{margin-left:-5px}.rfip.rfip--dividers{margin:8px 0;display:block}.kt-inspect-tabs .components-button-group .kt-layout-btn.is-primary{z-index:0}.kt-prebuilt-header{display:-ms-flexbox;display:flex;-ms-flex-pack:justify;justify-content:space-between;padding:0 10px}.components-button-group.kt-size-type-options.kt-row-size-type-options{float:right}.wp-block.is-selected[data-type="kadence/rowlayout"] .kt-resizeable-column-container .components-button.kt-fluid-grid-btn.is-button{opacity:1;z-index:1010}.kt-resizeable-column-container .components-button.kt-fluid-grid-btn.is-button{position:absolute;opacity:0;right:-10px;top:0;background:white;border:0;height:20px;line-height:20px;padding:0;width:20px;color:#0085ba;z-index:-1;-webkit-box-shadow:none;box-shadow:none}.kt-resizeable-column-container .components-button.kt-fluid-grid-btn.is-button svg{fill:currentColor}.rfipbtn.rfipbtn--dividers{background-color:#fff;border:1px solid #e0e0e0;width:96%}.rfipbtn.rfipbtn--dividers:active,.rfipbtn.rfipbtn--dividers:focus{border:1px solid #bdbdbd}.rfipbtn.rfipbtn--dividers .rfipbtn__current{-ms-flex:100%;flex:100%;-ms-flex-pack:start;justify-content:flex-start;padding:0}.rfipbtn.rfipbtn--dividers .rfipbtn__current svg.top-icon{-webkit-transform:rotate(180deg) !important;-ms-transform:rotate(180deg) !important;transform:rotate(180deg) !important}.rfipbtn.rfipbtn--dividers .rfipbtn__current .rfipbtn__icon{width:100%}.rfipbtn.rfipbtn--dividers .rfipbtn__current .rfipbtn__icon .rfipbtn__elm{width:100%}.rfipbtn.rfipbtn--dividers .rfipbtn__button{border:0 none transparent;border-left:1px solid #e0e0e0;background-color:#f5f5f5;color:#424242}.rfipbtn.rfipbtn--dividers .rfipbtn__button:hover{background-color:#bdbdbd}.rfipbtn.rfipbtn--dividers .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #e0e0e0;box-shadow:inset 0 0 10px 0 #e0e0e0}.rfipbtn.rfipbtn--dividers .rfipbtn__icon{border:0;color:#424242}.rfipbtn.rfipbtn--dividers .rfipbtn__icon--empty{color:#555d66;text-transform:none;text-align:left}.rfipbtn.rfipbtn--dividers .rfipbtn__del{background-color:#eee}.rfipbtn.rfipbtn--dividers .rfipbtn__del:hover{background-color:#e0e0e0}.rfipbtn.rfipbtn--dividers .rfipbtn__del:focus,.rfipbtn.rfipbtn--dividers .rfipbtn__del:active{outline:1px solid #e0e0e0}.rfipdropdown.rfipdropdown--dividers{max-height:240px;overflow:scroll}.rfipdropdown.rfipdropdown--dividers{background-color:#fff;border:1px solid #e0e0e0}.rfipdropdown.rfipdropdown--dividers .rfipdropdown__selector{overflow:hidden;padding:8px}.rfipdropdown.rfipdropdown--dividers .rfipicons__pager{display:none}.rfipdropdown.rfipdropdown--dividers .rfipicons__cp{border-bottom:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--dividers .rfipicons__cp:focus{border-bottom-color:#9e9e9e}.rfipdropdown.rfipdropdown--dividers .rfipicons__left,.rfipdropdown.rfipdropdown--dividers .rfipicons__right{background-color:#eee;border:1px solid #eee;color:#424242}.rfipdropdown.rfipdropdown--dividers .rfipicons__left:hover,.rfipdropdown.rfipdropdown--dividers .rfipicons__right:hover{background-color:#bdbdbd;border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--dividers .rfipicons__left:focus,.rfipdropdown.rfipdropdown--dividers .rfipicons__left:active,.rfipdropdown.rfipdropdown--dividers .rfipicons__right:focus,.rfipdropdown.rfipdropdown--dividers .rfipicons__right:active{border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--dividers .rfipicons__ibox{background-color:#f5f5f5;border:1px solid #f5f5f5;color:#424242}.rfipdropdown.rfipdropdown--dividers .rfipicons__ibox:hover{background-color:#bdbdbd;border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--dividers .rfipicons__ibox:focus,.rfipdropdown.rfipdropdown--dividers .rfipicons__ibox:active{border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--dividers .rfipicons__ibox--error{color:red}.rfipdropdown.rfipdropdown--dividers .rfipicons__icon{width:100%;height:50px;margin:2px 0}.rfipdropdown.rfipdropdown--dividers .rfipicons__icon svg{fill:#000;width:100%;-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1)}.rfipdropdown.rfipdropdown--dividers .rfipicons__icon svg.top-icon{-webkit-transform:rotate(180deg) !important;-ms-transform:rotate(180deg) !important;transform:rotate(180deg) !important}.rfipdropdown.rfipdropdown--dividers .rfipicons__icon--selected .rfipicons__ibox{background-color:#eee}.kt-select-layout>button.components-button.kt-prebuilt{background:#0085ba;color:white;padding:0;margin:0;line-height:45px;font-size:14px;font-weight:bold;margin-top:10px;margin-right:10px;margin-bottom:10px;height:45px;padding:0 10px;text-align:center;border:0;border-radius:0;-webkit-box-shadow:none;box-shadow:none}.kt-select-layout>button.components-button.kt-prebuilt:hover,.kt-select-layout>button.components-button.kt-prebuilt:focus:enabled{background:#006994;color:white;-webkit-box-shadow:none;box-shadow:none}.kt-prebuilt-modal .components-button-group{width:680px;padding-top:10px;display:grid;grid-template-columns:50% 50%;grid-gap:0}.kt-prebuilt-modal .components-modal__header .components-modal__header-heading{text-transform:uppercase;font-weight:bold}.kt-prebuilt-modal .components-base-control .components-base-control__field .components-base-control__label{font-weight:bold;line-height:30px;padding-right:10px}.kt-prebuilt-modal .components-base-control .components-base-control__field{display:-ms-flexbox;display:flex}.kt-prebuilt-modal .components-base-control .components-base-control__field select{max-width:200px}.kt-prebuilt-modal .kt-prebuilt-item{padding:0 10px 20px}.kt-prebuilt-modal .kt-prebuilt-item .kt-import-btn{padding-bottom:61%;border:5px solid #fff;border-radius:0 !important;height:0;background:#eee;width:100%;overflow:hidden;position:relative;-webkit-box-shadow:0 -1px 10px 0 rgba(0,0,0,0.07);box-shadow:0 -1px 10px 0 rgba(0,0,0,0.07)}.kt-prebuilt-modal .kt-prebuilt-item .kt-import-btn img{position:absolute;left:0;top:0;width:100%;height:auto;max-width:100%}.kt-prebuilt-modal .kt-prebuilt-item .kt-import-btn:hover{border:5px solid #0085ba}.kt-top-padding-resize{top:-14px}.kt-bottom-padding-resize{bottom:-14px}.kt-row-layout-top-sep{position:absolute;height:100px;top:-16px;left:0;overflow:hidden;right:0;z-index:1}.kt-row-layout-top-sep svg{position:absolute;top:0px;left:50%;-webkit-transform:translateX(-50%) rotate(180deg);-ms-transform:translateX(-50%) rotate(180deg);transform:translateX(-50%) rotate(180deg);width:100%;height:100%;display:block}.kt-row-layout-bottom-sep{position:absolute;height:100px;bottom:-16px;left:0;overflow:hidden;right:0;z-index:1}.kt-row-layout-bottom-sep svg{position:absolute;bottom:0px;left:50%;-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%);width:100%;height:100%;display:block}.components-range-control.kt-icon-rangecontrol .components-base-control__label{width:30px}.kt-cta-upload-btn{border:1px solid #ddd;margin-bottom:10px;border-radius:4px;display:-ms-inline-flexbox;display:inline-flex}.kt-remove-img.kt-cta-upload-btn{margin-left:5px}.kt-inspect-tabs .components-button-group{margin-bottom:1em}.edit-post-block-sidebar__panel .kt-inspect-tabs .components-panel__body{border-top:0;margin-top:6px;margin-bottom:0}.edit-post-block-sidebar__panel .kt-inspect-tabs .components-panel__body:not(:last-child){padding-bottom:0px}.kt-inspect-tabs{padding-top:10px}.kt-inspect-tabs .components-tab-panel__tabs{border-bottom:4px solid #ddd}.kt-inspect-tabs .components-tab-panel__tabs button{-ms-flex-pack:center;justify-content:center;background:transparent;border:0;border-bottom:4px solid transparent;padding:6px 16px;margin-bottom:-4px;outline:0}.kt-inspect-tabs .components-tab-panel__tabs button.active-tab{border-bottom-color:#0085ba;color:#0085ba}.kt-inspect-tabs.kt-gradient-tabs{padding-top:0}.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs{margin-bottom:15px}.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs button{background:transparent;border:0;border:1px solid #eee;border-bottom:4px solid transparent;padding:10px 16px 6px;margin-bottom:-4px;outline:0;color:#575757;width:50%;font-size:14px;font-weight:bold}.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs button.active-tab{background:#0085ba;color:white}.components-button-group .kt-layout-btn{height:36px;background:transparent;-webkit-box-shadow:none;box-shadow:none;border:1px solid #eee;padding:2px;margin-right:5px;margin-bottom:5px}.components-button-group .kt-layout-btn svg{width:60px;height:30px}.components-button-group .kt-layout-btn:hover,.components-button-group .kt-layout-btn.is-primary,.components-button-group .kt-layout-btn:focus:not(:disabled):not([aria-disabled=true]){border-color:#ddd;background:transparent;-webkit-box-shadow:none;box-shadow:none}.components-button-group .kt-layout-btn:hover svg rect{fill:#9EAAB5}.components-button-group .kt-layout-btn.is-primary svg rect{fill:#738495}.editor-block-list__block[data-type="kadence/rowlayout"].is-selected .editor-block-list__block-edit .wp-block-kadence-rowlayout-handler-top,.editor-block-list__block[data-type="kadence/rowlayout"].is-selected .editor-block-list__block-edit .wp-block-kadence-rowlayout-handler-bottom{display:block}.wp-block-kadence-rowlayout-handler-bottom{bottom:0px !important}.wp-block-kadence-rowlayout-handler-top{top:0px !important}.wp-block-kadence-rowlayout-handler-top,.wp-block-kadence-rowlayout-handler-bottom{display:none;border-radius:0;border:0;min-height:20px;width:100%;height:100% !important;position:absolute;background:transparent;padding:0;z-index:1000;cursor:se-resize;left:0px;margin-left:0px}.kt-padding-resize-box{z-index:10}.kt-row-padding{display:-ms-flexbox;display:flex;width:100%;height:100%;-ms-flex-pack:center;justify-content:center;-ms-flex-align:center;align-items:center;color:#777;opacity:0;-webkit-transition:opacity .3s ease;-o-transition:opacity .3s ease;transition:opacity .3s ease}.kt-row-padding span{background:rgba(255,255,255,0.7);padding:0 6px}.kt-row-has-bg .kt-row-padding{color:#000}.is-selected .kt-padding-resize-box:hover .kt-row-padding{opacity:1}.kadence-inner-column-inner{border:0 solid transparent}.wp-block-kadence-rowlayout .editor-block-list__layout{margin-left:0;margin-right:0}.wp-block-kadence-rowlayout .editor-block-list__layout:first-child{margin-left:-14px}.wp-block-kadence-rowlayout .editor-block-list__layout:last-child{margin-right:-14px}.wp-block-kadence-rowlayout .editor-block-list__layout .editor-block-list__block{max-width:none !important}.editor-block-list__block[data-type="kadence/rowlayout"]{clear:both}.editor-block-list__block[data-align=center][data-type="kadence/rowlayout"]{text-align:inherit}.editor-block-list__block[data-type="kadence/column"]>.editor-block-contextual-toolbar{top:38px;-webkit-transform:translateY(-38px);-ms-transform:translateY(-38px);transform:translateY(-38px);margin-left:-29px;margin-right:-29px}.editor-block-list__block[data-type="kadence/column"]>.editor-block-list__insertion-point{top:0;margin-top:0}.editor-block-list__block[data-align="full"] .wp-block-kadence-rowlayout>.editor-inner-blocks>.editor-block-list__layout:first-child{margin-left:30px}.editor-block-list__block[data-align="full"] .wp-block-kadence-rowlayout>.editor-inner-blocks>.editor-block-list__layout:last-child{margin-right:30px}.wp-block-kadence-rowlayout.kt-row-valign-middle{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;-ms-flex-pack:center;justify-content:center}.wp-block-kadence-rowlayout.kt-row-valign-middle>.innerblocks-wrap{width:100%}.wp-block-kadence-rowlayout.kt-row-valign-bottom{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;-ms-flex-pack:end;justify-content:flex-end}.wp-block-kadence-rowlayout.kt-row-valign-bottom>.innerblocks-wrap{width:100%}.editor-block-list__layout .editor-block-list__block[data-type="kadence/column"]>.editor-block-list__block-edit{margin-top:0;margin-bottom:0;padding-top:0.1px;padding-bottom:0.1px}.editor-block-list__layout .editor-block-list__block[data-type="kadence/column"]>.editor-block-list__block-edit>div:not(.editor-block-contextual-toolbar){width:100%}.editor-block-list__layout .editor-block-list__block[data-type="kadence/column"]>.editor-block-list__block-edit>.editor-block-contextual-toolbar{position:absolute;top:0;-webkit-transform:translateY(-39px);-ms-transform:translateY(-39px);transform:translateY(-39px)}.wp-block-kadence-rowlayout>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]>.editor-block-list__block-edit:before{bottom:0;top:0}.kt-row-has-bg .innerblocks-wrap{padding-left:15px;padding-right:15px}.editor-block-list__block[data-align="full"] .wp-block-kadence-rowlayout{padding-left:15px;padding-right:15px}.wp-block-kadence-rowlayout{display:block;position:relative}.wp-block-kadence-rowlayout>.innerblocks-wrap{z-index:10;position:relative;margin:0 auto;display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column}.wp-block-kadence-rowlayout>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout{display:-ms-flexbox;display:flex;-ms-flex-wrap:nowrap;flex-wrap:nowrap;-ms-flex-pack:justify;justify-content:space-between;margin-left:-14px;margin-right:-14px}.wp-block-kadence-rowlayout>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;-ms-flex:1;flex:1;min-width:0;word-break:break-word;overflow-wrap:break-word;max-width:none;margin-top:-14px;margin-bottom:-14px}.wp-block-kadence-rowlayout>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"] .editor-block-list__block-edit{-ms-flex-preferred-size:100%;flex-basis:100%}.wp-block-kadence-rowlayout.kt-row-layout-left-golden>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child{-ms-flex:0 1 66.67%;flex:0 1 66.67%}.wp-block-kadence-rowlayout.kt-row-layout-left-golden>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{-ms-flex:0 1 33.33%;flex:0 1 33.33%}.wp-block-kadence-rowlayout.kt-row-layout-right-golden>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child{-ms-flex:0 1 33.33%;flex:0 1 33.33%}.wp-block-kadence-rowlayout.kt-row-layout-right-golden>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{-ms-flex:0 1 66.67%;flex:0 1 66.67%}.wp-block-kadence-rowlayout.kt-row-layout-row>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout{-ms-flex-direction:column;flex-direction:column}.wp-block-kadence-rowlayout.kt-row-layout-row>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:none;flex:none;width:100%;margin-right:0;margin-bottom:30px}.wp-block-kadence-rowlayout.kt-row-layout-left-half>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:0 1 25%;flex:0 1 25%}.wp-block-kadence-rowlayout.kt-row-layout-left-half>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child{-ms-flex:0 1 50%;flex:0 1 50%}.wp-block-kadence-rowlayout.kt-row-layout-right-half>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:0 1 25%;flex:0 1 25%}.wp-block-kadence-rowlayout.kt-row-layout-right-half>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{-ms-flex:0 1 50%;flex:0 1 50%}.wp-block-kadence-rowlayout.kt-row-layout-center-half>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:0 1 50%;flex:0 1 50%}.wp-block-kadence-rowlayout.kt-row-layout-center-half>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child{-ms-flex:0 1 25%;flex:0 1 25%}.wp-block-kadence-rowlayout.kt-row-layout-center-half>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{-ms-flex:0 1 25%;flex:0 1 25%}.wp-block-kadence-rowlayout.kt-row-layout-center-wide>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:0 1 60%;flex:0 1 60%}.wp-block-kadence-rowlayout.kt-row-layout-center-wide>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child{-ms-flex:0 1 20%;flex:0 1 20%}.wp-block-kadence-rowlayout.kt-row-layout-center-wide>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{-ms-flex:0 1 20%;flex:0 1 20%}.wp-block-kadence-rowlayout.kt-row-layout-center-exwide>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:0 1 70%;flex:0 1 70%}.wp-block-kadence-rowlayout.kt-row-layout-center-exwide>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child{-ms-flex:0 1 15%;flex:0 1 15%}.wp-block-kadence-rowlayout.kt-row-layout-center-exwide>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{-ms-flex:0 1 15%;flex:0 1 15%}.wp-block-kadence-rowlayout.kt-row-layout-left-forty>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:1;flex:1}.wp-block-kadence-rowlayout.kt-row-layout-left-forty>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child{-ms-flex:2;flex:2}.wp-block-kadence-rowlayout.kt-row-layout-right-forty>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:1;flex:1}.wp-block-kadence-rowlayout.kt-row-layout-right-forty>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{-ms-flex:2;flex:2}.wp-block-kadence-rowlayout.kt-row-valign-middle>.innerblocks-wrap{-ms-flex-pack:center;justify-content:center}.wp-block-kadence-rowlayout.kt-row-valign-bottom>.innerblocks-wrap{-ms-flex-pack:end;justify-content:flex-end}.wp-block-kadence-rowlayout.kt-row-valign-middle>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]>.editor-block-list__block-edit{-ms-flex-align:center;align-items:center;display:-ms-flexbox;display:flex}.wp-block-kadence-rowlayout.kt-row-valign-bottom>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]>.editor-block-list__block-edit{-ms-flex-align:end;align-items:flex-end;display:-ms-flexbox;display:flex}.kt-row-layout-overlay,.kt-row-layout-background{top:-16px;bottom:-16px;left:0;position:absolute;height:auto;width:100%}.kt-select-layout-title{text-transform:uppercase;padding-bottom:10px;font-size:16px}.kt-select-layout{padding:30px;border:2px dashed #ddd;text-align:center;position:relative;z-index:10}.kt-select-layout .components-button-group .kt-layout-btn{height:49px;border:0;margin-right:10px;margin-bottom:10px}.kt-select-layout .components-button-group .kt-layout-btn svg{width:90px;height:45px}.kadence-column{width:100%}.kt-gutter-default>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{margin-right:30px}.kt-gutter-skinny>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{margin-right:10px}.kt-gutter-narrow>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{margin-right:20px}.kt-gutter-wide>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{margin-right:40px}.kt-gutter-wider>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{margin-right:60px}.kt-gutter-widest>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{margin-right:80px}.wp-block-kadence-rowlayout:not(.kt-gutter-none)>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:last-child{margin-right:0px}.editor-row-first-column__resizer{position:absolute !important;left:0;height:100% !important;background:transparent;top:0}.editor-row-first-column__resizer .components-resizable-box__handle{z-index:1000}.editor-row-first-column__resizer .components-resizable-box__handle:before{top:50%;position:absolute;left:50%;-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%);margin-top:-8px;z-index:2}.editor-row-first-column__resizer .components-resizable-box__handle:after{background:rgba(0,0,0,0.1);border:none;border-radius:0;content:"";cursor:inherit;display:block;height:100%;position:absolute;left:50%;-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%);width:2px;top:0}.kt-resizeable-column-container{margin-left:-14px;margin-right:-14px;position:absolute !important;height:100%;width:auto;left:0;right:0}.kt-block-defaults-modal .kt-inspect-tabs p.kt-measurement-label{color:#23282d;margin:1em 0;font-weight:bold}.wp-block.is-selected[data-type="kadence/rowlayout"] .editor-row-first-column__resizer .left-column-width-size{z-index:100;opacity:1}.wp-block-kadence-rowlayout:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none)>.innerblocks-wrap>.kt-resizeable-column-container .editor-row-first-column__resizer .components-resizable-box__handle{width:30px !important;right:0 !important;margin-right:-15px;padding:0}.left-column-width-size{right:-10px;padding-right:10px;margin-left:0}.column-width-size-handle{opacity:0;position:absolute;top:50%;font-size:12px;background:rgba(255,255,255,0.9);z-index:-1;width:70px;height:40px;color:#222;text-align:center;line-height:40px;margin-top:-20px}.wp-block.is-selected[data-type="kadence/rowlayout"] .editor-row-first-column__resizer .right-column-width-size{z-index:100;opacity:1}.right-column-width-size{left:100%;padding-left:10px;margin-left:-10px}.wp-block.is-selected[data-type="kadence/rowlayout"] .editor-row-first-column__resizer .components-resizable-box__handle{display:block}@media (max-width: 600px){.wp-block-kadence-rowlayout>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout{-ms-flex-direction:column;flex-direction:column}.wp-block-kadence-rowlayout>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]{-ms-flex:none !important;flex:none !important;width:100%;margin-right:0}.kt-resizeable-column-container{display:none}}.editor-block-list__block[data-type="kadence/rowlayout"]>.editor-block-list__block-edit:before{pointer-events:inherit}.editor-block-list__block[data-type="kadence/rowlayout"]>.editor-block-list__insertion-point{height:16px}.editor-block-list__block[data-type="kadence/rowlayout"]>.editor-block-list__insertion-point .editor-block-list__insertion-point-inserter{height:16px}.editor-block-list__block[data-type="kadence/rowlayout"][data-align=full]>.editor-block-list__block-edit>div>.wp-block-kadence-rowlayout:not(.kt-has-1-columns)>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child>.editor-block-list__block-edit>div>.kadence-column>.kadence-inner-column-inner>.editor-inner-blocks>.editor-block-list__layout>.editor-block-list__block>.editor-block-mover{left:1px;top:-34px;width:auto;height:auto;min-height:0}.editor-block-list__block[data-type="kadence/rowlayout"][data-align=full]>.editor-block-list__block-edit>div>.wp-block-kadence-rowlayout:not(.kt-has-1-columns)>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child>.editor-block-list__block-edit>div>.kadence-column>.kadence-inner-column-inner>.editor-inner-blocks>.editor-block-list__layout>.editor-block-list__block>.editor-block-mover .editor-block-mover__control{float:left}.editor-block-list__block[data-type="kadence/rowlayout"][data-align=full]>.editor-block-list__block-edit>div>.wp-block-kadence-rowlayout:not(.kt-has-1-columns)>.innerblocks-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-type="kadence/column"]:first-child>.editor-block-list__block-edit>div>.kadence-column>.kadence-inner-column-inner>.editor-inner-blocks>.editor-block-list__layout>.editor-block-list__block.is-selected>.editor-block-mover{top:-70px}.wp-block-kadence-rowlayout .editor-block-list__layout .editor-block-list__block{-webkit-backface-visibility:hidden;backface-visibility:hidden}.wp-block-image img{-webkit-backface-visibility:hidden;backface-visibility:hidden}.kt-row-layout-overlay,.kt-row-layout-background,.kt-row-layout-bottom-sep,.kt-row-layout-top-sep,.editor-block-list__block[data-type="kadence/rowlayout"]{-webkit-backface-visibility:hidden;backface-visibility:hidden}
-.wp-block-kadence-icon{min-width:20px;min-height:10px}.rfipbtn,.rfipdropdown{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;font-size:14px;line-height:1.71429;vertical-align:baseline}.rfipbtn,.rfipbtn *,.rfipdropdown,.rfipdropdown *{margin:0;padding:0;-webkit-box-sizing:border-box;box-sizing:border-box}.rfipbtn input,.rfipbtn select,.rfipdropdown input,.rfipdropdown select{font-size:14px}.rfip{position:relative;display:inline-block;margin:8px;vertical-align:middle}.rfipbtn{width:136px;display:-ms-flexbox;display:flex;-ms-flex-flow:row nowrap;flex-flow:row nowrap;min-height:50px;border-radius:2px;cursor:pointer;-webkit-transition:border-color .25s,-webkit-box-shadow .25s;transition:border-color .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border-color .25s;transition:box-shadow .25s,border-color .25s;transition:box-shadow .25s,border-color .25s,-webkit-box-shadow .25s;outline:0 none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.rfipbtn--open{border-radius:2px 2px 0 0}.rfipbtn__button{width:48px;margin-left:auto;display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;height:auto;-webkit-transition:background .25s,-webkit-box-shadow .25s;transition:background .25s,-webkit-box-shadow .25s;-o-transition:background .25s,box-shadow .25s;transition:background .25s,box-shadow .25s;transition:background .25s,box-shadow .25s,-webkit-box-shadow .25s}.rfipbtn__button i{font-size:32px;-webkit-transition:-webkit-transform .25s;transition:-webkit-transform .25s;-o-transition:transform .25s;transition:transform .25s;transition:transform .25s, -webkit-transform .25s;transition:transform .25s,-webkit-transform .25s}.rfipbtn__button--open i{-webkit-transform:rotate(-180deg);-ms-transform:rotate(-180deg);transform:rotate(-180deg)}.rfipbtn__current{display:-ms-flexbox;display:flex;-ms-flex-flow:row nowrap;flex-flow:row nowrap;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;-ms-flex:0 0 86px;flex:0 0 86px;padding:2px}.rfipbtn--multi{width:258px}.rfipbtn--multi .rfipbtn__current{-ms-flex-flow:row wrap;flex-flow:row wrap;-ms-flex-pack:start;justify-content:flex-start;-ms-flex-preferred-size:212px;flex-basis:212px;-ms-flex-line-pack:center;align-content:center}.rfipbtn--multi .rfipbtn__current,.rfipbtn__icon{}.rfipbtn__icon{margin:2px;padding:0;height:28px;width:48px;display:-ms-flexbox;display:flex;-ms-flex-flow:row nowrap;flex-flow:row nowrap;-ms-flex-align:center;align-items:center;-ms-flex-pack:justify;justify-content:space-between;border-radius:2px}.rfipbtn__icon--empty{font-size:14px;line-height:16px;margin-left:8px;text-align:center;text-transform:lowercase;font-style:italic}.rfipbtn__elm{display:-ms-flexbox;display:flex;height:28px;width:28px;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;font-size:18px}.rfipbtn__elm img,.rfipbtn__elm svg{height:18px;width:auto}.rfipbtn__del{width:18px;display:-ms-flexbox;display:flex;height:28px;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;-webkit-transition:background-color .25s;-o-transition:background-color .25s;transition:background-color .25s;cursor:pointer}.rfipcategory{width:100%;margin:0 0 8px;position:relative}.rfipcategory select{width:100%;display:block;height:32px;line-height:32px;border-radius:0;-webkit-appearance:none;-moz-appearance:none;appearance:none;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:border .25s,box-shadow .25s;transition:border .25s,box-shadow .25s;transition:border .25s,box-shadow .25s,-webkit-box-shadow .25s;background-color:transparent !important}.rfipcategory i{position:absolute;right:2px;top:0;font-size:16px;line-height:32px;z-index:-1}.rfipdropdown{width:352px;position:absolute;left:0;margin-top:-1px;z-index:100000001;border-radius:0 1px 4px 4px}.rfipdropdown__selector{overflow:hidden;padding:16px}.rfipdropdown.fipappear-enter-active .rfipdropdown__selector,.rfipdropdown.fipappear-exit-active .rfipdropdown__selector{-webkit-transition:max-height .3s ease-out,padding .3s ease-out;-o-transition:max-height .3s ease-out,padding .3s ease-out;transition:max-height .3s ease-out,padding .3s ease-out;padding:16px}.rfipicons__pager{display:-ms-flexbox;display:flex;-ms-flex-flow:row nowrap;flex-flow:row nowrap;height:24px;line-height:24px;-ms-flex-align:center;align-items:center;margin-bottom:8px}.rfipicons__num{width:100px;margin-right:auto}.rfipicons__cp{width:32px;height:24px;line-height:24px;text-align:right}.rfipicons__cp,.rfipicons__sp,.rfipicons__tp{margin-right:8px}.rfipicons__arrow{margin-left:auto;width:56px;display:-ms-flexbox;display:flex;-ms-flex-flow:row nowrap;flex-flow:row nowrap;-ms-flex-pack:end;justify-content:flex-end;-ms-flex-align:center;align-items:center;height:24px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.rfipicons__right{margin-left:auto}.rfipicons__left,.rfipicons__right{cursor:pointer;width:24px;height:24px;position:relative;-webkit-transition:background-color .25s,border .25s;-o-transition:background-color .25s,border .25s;transition:background-color .25s,border .25s;outline:0 none;border-radius:2px;font-size:18px}.rfipicons__label{height:22px;width:22px;display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center}.rfipicons__label img{height:18px;width:18px}.rfipicons__selector{-ms-flex:1 1 20%;flex:1 1 20%;-ms-flex-flow:row wrap;flex-flow:row wrap;-ms-flex-line-pack:center;align-content:center;-ms-flex-pack:start;justify-content:flex-start}.rfipicons__ibox,.rfipicons__selector{display:-ms-flexbox;display:flex}.rfipicons__ibox{-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;height:100%;width:100%;-webkit-transition:background-color .25s,border .25s;-o-transition:background-color .25s,border .25s;transition:background-color .25s,border .25s;border-radius:2px;outline:0 none;font-size:20px}.rfipicons__ibox img,.rfipicons__ibox svg{max-height:24px;width:auto}.rfipicons__ibox>*{-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1);-webkit-transition:-webkit-transform .25s;transition:-webkit-transform .25s;-o-transition:transform .25s;transition:transform .25s;transition:transform .25s, -webkit-transform .25s;transition:transform .25s,-webkit-transform .25s;-webkit-transform-origin:center;-ms-transform-origin:center;transform-origin:center}.rfipicons__ibox:hover>*{-webkit-transform:scale(1.8);-ms-transform:scale(1.8);transform:scale(1.8)}.rfipicons__ibox--error{text-transform:lowercase;font-style:italic}.rfipicons__icon{width:20%;height:64px;padding:1px;display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;cursor:pointer}.rfipicons__icon--error{display:block;padding:16px;text-align:center;font-size:24px;width:100%;line-height:1}.rfipsearch{width:100%;margin:0 0 8px}.rfipsearch input{width:100%;display:block;height:32px;line-height:32px}/*!
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.editor-block-list__block[data-type="kadence/spacer"].is-selected .editor-block-list__block-edit .kadence-spacer__resize-handler-top,
+.editor-block-list__block[data-type="kadence/spacer"].is-selected .editor-block-list__block-edit .kadence-spacer__resize-handler-bottom {
+  display: block; }
+
+.kt-inspect-tabs.kt-spacer-tabs .components-tab-panel__tabs {
+  margin-bottom: 10px; }
+
+.kadence-spacer__resize-handler-top,
+.kadence-spacer__resize-handler-bottom {
+  display: none;
+  border-radius: 50%;
+  border: 2px solid white;
+  width: 15px !important;
+  height: 15px !important;
+  position: absolute;
+  background: #0085ba;
+  padding: 0 3px 3px 0;
+  cursor: se-resize;
+  left: 50% !important;
+  margin-left: -7.5px; }
+
+.kt-spacer-height-preview {
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  -ms-flex-pack: center;
+      justify-content: center;
+  -ms-flex-align: center;
+      align-items: center;
+  color: #777;
+  opacity: 0;
+  -webkit-transition: opacity .3s ease;
+  -o-transition: opacity .3s ease;
+  transition: opacity .3s ease; }
+  .kt-spacer-height-preview span {
+    background: rgba(255, 255, 255, 0.7);
+    padding: 0 6px; }
+
+.is-selected .kt-block-spacer:hover .kt-spacer-height-preview {
+  opacity: 1; }
+
+.kt-block-spacer {
+  position: relative;
+  height: 100%;
+  border: dashed 1px #eee; }
+
+.kt-block-spacer .kt-divider {
+  width: 100%;
+  border-top: solid 1px #eee;
+  position: absolute;
+  top: 50%;
+  margin: 0;
+  padding: 0;
+  border-bottom: 0;
+  border-left: 0;
+  border-right: 0;
+  left: 50%;
+  -webkit-transform: perspective(1px) translate(-50%, -50%);
+          transform: perspective(1px) translate(-50%, -50%); }
+
+.kt-block-spacer.kt-block-spacer-halign-left .kt-divider {
+  left: 0;
+  -webkit-transform: perspective(1px) translate(0%, -50%);
+          transform: perspective(1px) translate(0%, -50%); }
+
+.kt-block-spacer.kt-block-spacer-halign-right .kt-divider {
+  left: auto;
+  right: 0;
+  -webkit-transform: perspective(1px) translate(0%, -50%);
+          transform: perspective(1px) translate(0%, -50%); }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.kt-button-text.is-selected {
+  min-width: 5px; }
+
+.block-editor-rich-text__editable.kt-button-text [data-rich-text-placeholder]:after {
+  display: inline-block; }
+
+.block-editor-rich-text__editable.kt-button-text.is-selected:focus [data-rich-text-placeholder]:after {
+  display: none; }
+
+.kt-block-defaults-modal h2.kt-beside-btn-group, .kt-block-defaults-modal h2.kt-beside-color-label {
+  font-size: 14px;
+  color: #555d66; }
+
+.kt-block-defaults-modal h2.kt-tab-wrap-title.kt-color-settings-title {
+  text-align: center;
+  background: #f2f2f2;
+  margin-bottom: 0;
+  font-size: 14px;
+  color: #555d66; }
+
+.kt-btn-link-group .kt-btn-link-input input[type=text] {
+  max-width: 97%;
+  width: 100%; }
+
+.kt-btn-link-group {
+  display: -ms-flexbox;
+  display: flex;
+  max-width: 100%; }
+
+.edit-post-sidebar h2.side-h2-label {
+  margin-bottom: 4px; }
+
+.kt-inspect-tabs .kt-btn-size-settings-container .kt-button-size-type-options {
+  margin-bottom: 0; }
+
+.kt-btn-size-settings-container .kt-button-size-type-options {
+  margin-bottom: 0; }
+
+.kt-box-shadow-label .components-base-control.components-toggle-control, .kt-box-shadow-label .components-toggle-control .components-base-control__field {
+  margin-bottom: 0 !important; }
+
+.kt-box-shadow-label h2.kt-beside-color-label {
+  -ms-flex-positive: 1;
+      flex-grow: 1;
+  margin: 12px 0; }
+
+.kt-box-shadow-label {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center; }
+
+.kt-select-icon-container .rfip {
+  margin: 0 0 15px 0; }
+
+.kt-inner-sub-section-row {
+  display: -ms-flexbox;
+  display: flex;
+  margin-bottom: 10px; }
+
+.kt-box-shadow-subset {
+  padding: 0 2px;
+  text-align: center; }
+
+.kt-box-shadow-subset .kt-box-shadow-title {
+  font-size: 12px; }
+
+.kt-box-shadow-subset .kt-advanced-color-settings-container {
+  -ms-flex-direction: column-reverse;
+      flex-direction: column-reverse; }
+
+.edit-post-sidebar h2.kt-tab-wrap-title.kt-color-settings-title {
+  text-align: center;
+  background: #f2f2f2;
+  margin-bottom: 0; }
+
+.kt-advanced-color-settings-container .kt-has-alpha {
+  background-image: -webkit-linear-gradient(45deg, #ddd 25%, transparent 0), -webkit-linear-gradient(135deg, #ddd 25%, transparent 0), -webkit-linear-gradient(45deg, transparent 75%, #ddd 0), -webkit-linear-gradient(135deg, transparent 75%, #ddd 0);
+  background-image: -o-linear-gradient(45deg, #ddd 25%, transparent 0), -o-linear-gradient(135deg, #ddd 25%, transparent 0), -o-linear-gradient(45deg, transparent 75%, #ddd 0), -o-linear-gradient(135deg, transparent 75%, #ddd 0);
+  background-image: linear-gradient(45deg, #ddd 25%, transparent 0), linear-gradient(-45deg, #ddd 25%, transparent 0), linear-gradient(45deg, transparent 75%, #ddd 0), linear-gradient(-45deg, transparent 75%, #ddd 0);
+  background-size: 10px 10px;
+  background-position: 0 0,0 5px,5px -5px,-5px 0; }
+
+.kt-advanced-color-settings-container .kt-color-icon-indicate {
+  position: relative;
+  -webkit-transform: scale(1);
+      -ms-transform: scale(1);
+          transform: scale(1);
+  -webkit-transition: -webkit-transform .1s ease;
+  transition: -webkit-transform .1s ease;
+  -o-transition: transform .1s ease;
+  transition: transform .1s ease;
+  transition: transform .1s ease, -webkit-transform .1s ease;
+  border-radius: 50%;
+  padding: 0; }
+
+.kt-advanced-color-settings-container .kt-color-icon-indicate:hover {
+  -webkit-transform: scale(1.2);
+      -ms-transform: scale(1.2);
+          transform: scale(1.2); }
+
+.components-popover__content .components-range-control.kt-opacity-value {
+  padding: 0 12px 12px; }
+
+.components-popover__content .components-range-control.kt-opacity-value .components-base-control__field {
+  -ms-flex-wrap: nowrap;
+      flex-wrap: nowrap; }
+
+.components-popover__content .components-range-control.kt-opacity-value .components-range-control__slider {
+  -ms-flex-positive: 10;
+      flex-grow: 10; }
+
+.components-popover__content .components-range-control.kt-opacity-value .components-base-control__label {
+  width: auto;
+  margin-right: 5px; }
+
+.kt-advanced-color-settings-container .components-color-palette__clear svg {
+  width: 16px; }
+
+.kt-advanced-color-settings-container .components-color-palette__clear {
+  background: transparent;
+  padding: 4px;
+  height: auto;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  border: 1px solid transparent; }
+
+.kt-beside-color-click {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center; }
+
+.kt-advanced-color-settings-container .kt-color-icon-indicate .component-color-indicator.kt-advanced-color-indicate {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  margin: 0; }
+
+.components-popover__content .components-color-palette .components-color-palette__item-wrapper {
+  margin-right: 5px;
+  margin-bottom: 10px;
+  margin-left: 5px; }
+
+.components-popover__content .components-color-palette .components-color-palette__item-wrapper:last-child {
+  margin-right: 0; }
+
+.components-popover__content .components-color-palette {
+  margin: 0;
+  padding: 0px 12px 12px;
+  width: 100%; }
+
+.kt-advanced-color-settings-container {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center; }
+
+.kt-advanced-color-settings-container h2.kt-beside-color-label {
+  -ms-flex-positive: 1;
+      flex-grow: 1; }
+
+.kt-link-settings {
+  border: 1px solid #8d96a0;
+  margin: 2px 0;
+  height: 30px;
+  padding: 2px 8px; }
+
+.kt-inner-sub-section {
+  border: 1px solid #ddd;
+  border-top: 0;
+  padding: 25px 10px 10px 10px;
+  margin-bottom: 15px;
+  margin-top: -15px; }
+
+.kt-inner-sub-section .kt-size-tabs .components-tab-panel__tabs {
+  margin-bottom: 10px; }
+
+.kt-btn-size-settings-container .kt-beside-btn-group {
+  -ms-flex-positive: 1;
+      flex-grow: 1;
+  margin: 0; }
+
+.btn-text-size-range {
+  margin-top: 8px; }
+
+.edit-post-sidebar h2.kt-heading-size-title.kt-secondary-color-size {
+  margin-top: 0;
+  font-weight: normal; }
+
+.kt-btn-size-settings-container {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  margin: 20px 0; }
+
+.kt-link-settings .dashicon {
+  width: 16px;
+  height: 16px; }
+
+.kt-button-size-type-options .dashicon {
+  width: 14px; }
+
+.components-base-control__field .components-range-control__slider + .dashicon.dashicons-editor-textcolor {
+  width: 30px;
+  height: 30px; }
+
+.kt-popover-container {
+  float: left;
+  margin-top: -20px; }
+
+.components-popover.kt-popover-opacity .components-popover__content {
+  padding: 10px; }
+
+.components-popover.kt-popover-opacity .components-popover__content .components-base-control .components-base-control__field {
+  margin: 0; }
+
+.kt-popover-container .components-button.is-button {
+  background: transparent;
+  height: 20px;
+  padding: 0;
+  width: 20px;
+  border: 0;
+  -webkit-box-shadow: none !important;
+          box-shadow: none !important; }
+
+.kt-popover-container .components-button.is-button svg {
+  opacity: 1;
+  -webkit-transition: all .3s ease-in-out;
+  -o-transition: all .3s ease-in-out;
+  transition: all .3s ease-in-out; }
+
+.kt-popover-container .components-button.is-button:hover svg {
+  opacity: 0.7; }
+
+.wp-block-kadence-advancedbtn form.blocks-button__inline-link {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  font-size: 13px;
+  line-height: 1.4;
+  width: 340px; }
+
+.components-panel__body.kt-font-family-area.is-opened {
+  min-height: 340px; }
+
+.kt-color-indicate {
+  display: block;
+  float: right;
+  margin-bottom: -18px;
+  margin-top: 10px; }
+
+.components-panel__body.kt-font-family-area h2.kt-heading-fontfamily-title {
+  margin-top: 0; }
+
+.wp-block-kadence-advancedbtn .btn-area-wrap form.blocks-button__inline-link {
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  border: 1px solid #eee;
+  padding: 0;
+  background: white;
+  -webkit-transform: translate(-50%, 0);
+      -ms-transform: translate(-50%, 0);
+          transform: translate(-50%, 0); }
+
+.kt-hover-tabs {
+  padding-top: 0;
+  margin-top: -5px; }
+
+.kt-hover-tabs .components-tab-panel__tabs {
+  margin-bottom: 15px; }
+
+.kt-hover-tabs .components-tab-panel__tabs button.active-tab {
+  border-color: #0085ba;
+  color: #0085ba; }
+
+.kt-hover-tabs .components-tab-panel__tabs button {
+  background: transparent;
+  border: 0;
+  border: 1px solid #eee;
+  border-bottom: 4px solid transparent;
+  padding: 6px 16px;
+  margin-bottom: -4px;
+  outline: 0;
+  color: #575757;
+  width: 50%;
+  font-size: 14px;
+  font-weight: bold; }
+
+.wp-block-kadence-advancedbtn.kt-btn-align-left .btn-area-wrap form.blocks-button__inline-link {
+  left: 0;
+  -webkit-transform: translate(0, 0);
+      -ms-transform: translate(0, 0);
+          transform: translate(0, 0); }
+
+.wp-block-kadence-advancedbtn.kt-btn-align-right .btn-area-wrap form.blocks-button__inline-link {
+  left: auto;
+  right: 0;
+  -webkit-transform: translate(0, 0);
+      -ms-transform: translate(0, 0);
+          transform: translate(0, 0); }
+
+.wp-block-kadence-advancedbtn .btn-area-wrap {
+  position: relative;
+  display: inline-block; }
+
+[data-type="kadence/advancedbtn"].is-selected .wp-block-kadence-advancedbtn, [data-type="kadence/advancedbtn"].is-typing .wp-block-kadence-advancedbtn {
+  padding-bottom: 40px; }
+
+.kt-button {
+  z-index: 1;
+  position: relative;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 18px;
+  border-width: 2px;
+  border-radius: 3px;
+  border-color: #555555;
+  background: transparent;
+  color: #555555;
+  display: -ms-flexbox;
+  display: flex;
+  text-align: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  border-style: solid;
+  overflow: hidden;
+  -webkit-transition: all .3s ease-in-out;
+  -o-transition: all .3s ease-in-out;
+  transition: all .3s ease-in-out; }
+
+.kt-button::before {
+  position: absolute;
+  content: "";
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
+  opacity: 0;
+  background: #444444;
+  -webkit-transition: all .3s ease-in-out;
+  -o-transition: all .3s ease-in-out;
+  transition: all .3s ease-in-out; }
+
+.kt-button:hover {
+  border-color: #444444;
+  color: #ffffff; }
+
+.kt-button:hover::before {
+  opacity: 1; }
+
+.kt-btn-size-small {
+  font-size: 16px;
+  padding: 4px 8px;
+  border-width: 1px; }
+
+.kt-btn-size-large {
+  font-size: 20px;
+  padding: 12px 24px;
+  border-width: 3px; }
+
+.kt-btn-svg-icon.kt-btn-side-right {
+  padding-left: 5px; }
+
+.kt-btn-svg-icon.kt-btn-side-left {
+  padding-right: 5px; }
+
+.kt-button-wrap {
+  display: inline-block;
+  margin-bottom: 5px; }
+
+.kt-btn-align-center {
+  text-align: center; }
+
+.kt-btn-align-left {
+  text-align: left; }
+
+.kt-btn-align-right {
+  text-align: right; }
+
+.wp-block-kadence-advancedbtn .btn-area-wrap:last-child {
+  margin-right: 0; }
+
+.wp-block-kadence-advancedbtn .btn-area-wrap {
+  margin-right: 5px; }
+
+.kt-force-btn-fullwidth .btn-inner-wrap > div {
+  display: -ms-flexbox;
+  display: flex; }
+
+.wp-block-kadence-advancedbtn.kt-force-btn-fullwidth .btn-area-wrap {
+  display: block;
+  -ms-flex-positive: 1;
+      flex-grow: 1; }
+
+.wp-block-kadence-advancedbtn.kt-force-btn-fullwidth .btn-area-wrap .kt-button-wrap {
+  display: block; }
+
+.wp-block-kadence-advancedbtn.kt-force-btn-fullwidth .kt-button {
+  -ms-flex-pack: center;
+      justify-content: center; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-kadence-rowlayout .kb-blocks-bg-slider, .wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slider {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  padding: 0; }
+
+.wp-block-kadence-rowlayout .kb-blocks-bg-slider {
+  top: -16px;
+  bottom: -16px; }
+
+.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-track, .wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-list, .wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slide {
+  height: 100%; }
+
+.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slide div.kb-bg-slide {
+  background-position: center;
+  background-size: cover; }
+
+.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-dots {
+  bottom: 0; }
+
+.kb-blocks-bg-slider > .kb-bg-slide-contain, .kb-blocks-bg-slider > .kb-bg-slide-contain .kb-bg-slide {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  position: absolute; }
+
+.wp-block-kadence-rowlayout .kb-blocks-bg-slider .slick-slide div {
+  position: relative;
+  height: 100%; }
+
+.kb-blocks-bg-video-container {
+  right: 0;
+  left: 0;
+  top: -16px;
+  bottom: -16px;
+  position: absolute;
+  overflow: hidden; }
+
+.kb-blocks-bg-video {
+  -o-object-position: 50% 50%;
+     object-position: 50% 50%;
+  -o-object-fit: cover;
+     object-fit: cover;
+  background-position: center center;
+  width: 100%;
+  height: 100%; }
+
+div.kb-blocks-bg-video {
+  background-repeat: no-repeat;
+  background-size: cover; }
+
+.edit-post-settings-sidebar__panel-block .kt-inspect-tabs .components-panel__body:last-child {
+  margin-bottom: 0; }
+
+button.components-button.kb-sidebar-image {
+  width: 150px;
+  height: 40px;
+  margin-right: 5px;
+  background-position: center;
+  color: white;
+  text-shadow: 1px 1px 1px #000; }
+
+.kt-sidebar-settings-spacer {
+  height: 15px;
+  border-top: 1px solid #e2e4e7;
+  margin: 0 -16px;
+  background: #f9f9f9; }
+
+.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs button:focus {
+  -webkit-box-shadow: 0;
+          box-shadow: 0;
+  border: 0; }
+
+.kt-inner-column-height-full .kadence-inner-column-inner:before {
+  display: table;
+  clear: both;
+  content: ''; }
+
+.kt-inner-column-height-full .kadence-inner-column-inner {
+  height: 100%; }
+
+.kt-inner-column-height-full .editor-block-list__layout .editor-block-list__block[data-type="kadence/column"] > .editor-block-list__block-edit > div[data-block] {
+  height: 100%;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0;
+  padding-top: 28px;
+  padding-bottom: 28px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -30px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: -25px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-1"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: 5px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -25px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: -20px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: 0px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -22px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: -17px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: -3px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -18px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: -13px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: -7px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -12px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: -7px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: -13px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -8px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: -3px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-7"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: -17px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -5px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: 0px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-8"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: -20px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: 0px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .kt-fluid-grid-btn {
+  right: 5px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-first-width-9"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer:not(.second_resizer) .right-column-width-size {
+  margin-left: -25px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -40px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn {
+  right: -35px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-6"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size {
+  margin-left: 15px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right, .wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -35px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn, .wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size, .wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn {
+  right: -30px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-5"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size, .wp-block-kadence-rowlayout.kt-custom-third-width-right-half:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size {
+  margin-left: 10px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -30px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn {
+  right: -25px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-4"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size {
+  margin-left: 5px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -25px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn {
+  right: -20px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-3"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size {
+  margin-left: 0px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .components-resizable-box__handle.components-resizable-box__handle-right {
+  margin-right: -20px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .left-column-width-size, .wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .kt-fluid-grid-btn {
+  right: -15px; }
+
+.wp-block-kadence-rowlayout[class*=" kt-custom-third-width-2"]:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer.second_resizer .right-column-width-size {
+  margin-left: -5px; }
+
+.rfip.rfip--dividers {
+  margin: 8px 0;
+  display: block; }
+
+.kt-inspect-tabs .components-button-group .kt-layout-btn.is-primary {
+  z-index: 0; }
+
+.kt-prebuilt-header {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
+  padding: 0 10px; }
+
+.components-button-group.kt-size-type-options.kt-row-size-type-options {
+  float: right; }
+
+.wp-block.is-selected[data-type="kadence/rowlayout"] .kt-resizeable-column-container .components-button.kt-fluid-grid-btn.is-button {
+  opacity: 1;
+  z-index: 1010; }
+
+.kt-resizeable-column-container .components-button.kt-fluid-grid-btn.is-button {
+  position: absolute;
+  opacity: 0;
+  right: -10px;
+  top: 0;
+  background: white;
+  border: 0;
+  height: 20px;
+  line-height: 20px;
+  padding: 0;
+  width: 20px;
+  color: #0085ba;
+  z-index: -1;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+  .kt-resizeable-column-container .components-button.kt-fluid-grid-btn.is-button svg {
+    fill: currentColor; }
+
+.rfipbtn.rfipbtn--dividers {
+  background-color: #fff;
+  border: 1px solid #e0e0e0;
+  width: 96%; }
+  .rfipbtn.rfipbtn--dividers:active, .rfipbtn.rfipbtn--dividers:focus {
+    border: 1px solid #bdbdbd; }
+  .rfipbtn.rfipbtn--dividers .rfipbtn__current {
+    -ms-flex: 100%;
+        flex: 100%;
+    -ms-flex-pack: start;
+        justify-content: flex-start;
+    padding: 0; }
+    .rfipbtn.rfipbtn--dividers .rfipbtn__current svg.top-icon {
+      -webkit-transform: rotate(180deg) !important;
+          -ms-transform: rotate(180deg) !important;
+              transform: rotate(180deg) !important; }
+    .rfipbtn.rfipbtn--dividers .rfipbtn__current .rfipbtn__icon {
+      width: 100%; }
+      .rfipbtn.rfipbtn--dividers .rfipbtn__current .rfipbtn__icon .rfipbtn__elm {
+        width: 100%; }
+  .rfipbtn.rfipbtn--dividers .rfipbtn__button {
+    border: 0 none transparent;
+    border-left: 1px solid #e0e0e0;
+    background-color: #f5f5f5;
+    color: #424242; }
+    .rfipbtn.rfipbtn--dividers .rfipbtn__button:hover {
+      background-color: #bdbdbd; }
+    .rfipbtn.rfipbtn--dividers .rfipbtn__button:active {
+      -webkit-box-shadow: inset 0 0 10px 0 #e0e0e0;
+              box-shadow: inset 0 0 10px 0 #e0e0e0; }
+  .rfipbtn.rfipbtn--dividers .rfipbtn__icon {
+    border: 0;
+    color: #424242; }
+    .rfipbtn.rfipbtn--dividers .rfipbtn__icon--empty {
+      color: #555d66;
+      text-transform: none;
+      text-align: left; }
+  .rfipbtn.rfipbtn--dividers .rfipbtn__del {
+    background-color: #eee; }
+    .rfipbtn.rfipbtn--dividers .rfipbtn__del:hover {
+      background-color: #e0e0e0; }
+    .rfipbtn.rfipbtn--dividers .rfipbtn__del:focus, .rfipbtn.rfipbtn--dividers .rfipbtn__del:active {
+      outline: 1px solid #e0e0e0; }
+
+.rfipdropdown.rfipdropdown--dividers {
+  max-height: 240px;
+  overflow: scroll; }
+
+.rfipdropdown.rfipdropdown--dividers {
+  background-color: #fff;
+  border: 1px solid #e0e0e0; }
+  .rfipdropdown.rfipdropdown--dividers .rfipdropdown__selector {
+    overflow: hidden;
+    padding: 8px; }
+  .rfipdropdown.rfipdropdown--dividers .rfipicons__pager {
+    display: none; }
+  .rfipdropdown.rfipdropdown--dividers .rfipicons__cp {
+    border-bottom: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__cp:focus {
+      border-bottom-color: #9e9e9e; }
+  .rfipdropdown.rfipdropdown--dividers .rfipicons__left, .rfipdropdown.rfipdropdown--dividers .rfipicons__right {
+    background-color: #eee;
+    border: 1px solid #eee;
+    color: #424242; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__left:hover, .rfipdropdown.rfipdropdown--dividers .rfipicons__right:hover {
+      background-color: #bdbdbd;
+      border: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__left:focus, .rfipdropdown.rfipdropdown--dividers .rfipicons__left:active, .rfipdropdown.rfipdropdown--dividers .rfipicons__right:focus, .rfipdropdown.rfipdropdown--dividers .rfipicons__right:active {
+      border: 1px solid #bdbdbd; }
+  .rfipdropdown.rfipdropdown--dividers .rfipicons__ibox {
+    background-color: #f5f5f5;
+    border: 1px solid #f5f5f5;
+    color: #424242; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__ibox:hover {
+      background-color: #bdbdbd;
+      border: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__ibox:focus, .rfipdropdown.rfipdropdown--dividers .rfipicons__ibox:active {
+      border: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__ibox--error {
+      color: red; }
+  .rfipdropdown.rfipdropdown--dividers .rfipicons__icon {
+    width: 100%;
+    height: 50px;
+    margin: 2px 0; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__icon svg {
+      fill: #000;
+      width: 100%;
+      -webkit-transform: scale(1);
+          -ms-transform: scale(1);
+              transform: scale(1); }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__icon svg.top-icon {
+      -webkit-transform: rotate(180deg) !important;
+          -ms-transform: rotate(180deg) !important;
+              transform: rotate(180deg) !important; }
+    .rfipdropdown.rfipdropdown--dividers .rfipicons__icon--selected .rfipicons__ibox {
+      background-color: #eee; }
+
+.kt-select-layout > button.components-button.kt-prebuilt {
+  background: #0085ba;
+  color: white;
+  padding: 0;
+  margin: 0;
+  line-height: 45px;
+  font-size: 14px;
+  font-weight: bold;
+  margin-top: 10px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  height: 45px;
+  padding: 0 10px;
+  text-align: center;
+  border: 0;
+  border-radius: 0;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kt-select-layout > button.components-button.kt-prebuilt:hover, .kt-select-layout > button.components-button.kt-prebuilt:focus:enabled {
+  background: #006994;
+  color: white;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kt-prebuilt-modal .components-button-group {
+  width: 680px;
+  padding-top: 10px;
+  display: grid;
+  grid-template-columns: 50% 50%;
+  grid-gap: 0; }
+
+.kt-prebuilt-modal .components-modal__header .components-modal__header-heading {
+  text-transform: uppercase;
+  font-weight: bold; }
+
+.kt-prebuilt-modal .components-base-control .components-base-control__field .components-base-control__label {
+  font-weight: bold;
+  line-height: 30px;
+  padding-right: 10px; }
+
+.kt-prebuilt-modal .components-base-control .components-base-control__field {
+  display: -ms-flexbox;
+  display: flex; }
+
+.kt-prebuilt-modal .components-base-control .components-base-control__field select {
+  max-width: 200px; }
+
+.kt-prebuilt-modal .kt-prebuilt-item {
+  padding: 0 10px 20px; }
+  .kt-prebuilt-modal .kt-prebuilt-item .kt-import-btn {
+    padding-bottom: 61%;
+    border: 5px solid #fff;
+    border-radius: 0 !important;
+    height: 0;
+    background: #eee;
+    width: 100%;
+    overflow: hidden;
+    position: relative;
+    -webkit-box-shadow: 0 -1px 10px 0 rgba(0, 0, 0, 0.07);
+            box-shadow: 0 -1px 10px 0 rgba(0, 0, 0, 0.07); }
+    .kt-prebuilt-modal .kt-prebuilt-item .kt-import-btn img {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: auto;
+      max-width: 100%; }
+    .kt-prebuilt-modal .kt-prebuilt-item .kt-import-btn:hover {
+      border: 5px solid #0085ba; }
+
+.kt-top-padding-resize {
+  top: -14px; }
+
+.kt-bottom-padding-resize {
+  bottom: -14px; }
+
+.kt-row-layout-top-sep {
+  position: absolute;
+  height: 100px;
+  top: -16px;
+  left: 0;
+  overflow: hidden;
+  right: 0;
+  z-index: 1; }
+  .kt-row-layout-top-sep svg {
+    position: absolute;
+    top: 0px;
+    left: 50%;
+    -webkit-transform: translateX(-50%) rotate(180deg);
+        -ms-transform: translateX(-50%) rotate(180deg);
+            transform: translateX(-50%) rotate(180deg);
+    width: 100%;
+    height: 100%;
+    display: block; }
+
+.kt-row-layout-bottom-sep {
+  position: absolute;
+  height: 100px;
+  bottom: -16px;
+  left: 0;
+  overflow: hidden;
+  right: 0;
+  z-index: 1; }
+  .kt-row-layout-bottom-sep svg {
+    position: absolute;
+    bottom: 0px;
+    left: 50%;
+    -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+            transform: translateX(-50%);
+    width: 100%;
+    height: 100%;
+    display: block; }
+
+.components-range-control.kt-icon-rangecontrol .components-base-control__label {
+  width: 30px; }
+
+.kt-cta-upload-btn {
+  border: 1px solid #ddd;
+  margin-bottom: 10px;
+  border-radius: 4px;
+  display: -ms-inline-flexbox;
+  display: inline-flex; }
+
+.kt-remove-img.kt-cta-upload-btn {
+  margin-left: 5px; }
+
+.kt-inspect-tabs .components-button-group {
+  margin-bottom: 1em; }
+
+.edit-post-block-sidebar__panel .kt-inspect-tabs .components-panel__body {
+  border-top: 0;
+  margin-top: 6px;
+  margin-bottom: 0; }
+
+.edit-post-block-sidebar__panel .kt-inspect-tabs .components-panel__body:not(:last-child) {
+  padding-bottom: 0px; }
+
+.kt-inspect-tabs {
+  padding-top: 10px; }
+  .kt-inspect-tabs .components-tab-panel__tabs {
+    border-bottom: 4px solid #ddd; }
+    .kt-inspect-tabs .components-tab-panel__tabs button {
+      -ms-flex-pack: center;
+          justify-content: center;
+      background: transparent;
+      border: 0;
+      border-bottom: 4px solid transparent;
+      padding: 6px 16px;
+      margin-bottom: -4px;
+      outline: 0; }
+    .kt-inspect-tabs .components-tab-panel__tabs button.active-tab {
+      border-bottom-color: #0085ba;
+      color: #0085ba; }
+
+.kt-inspect-tabs.kt-gradient-tabs {
+  padding-top: 0; }
+
+.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs {
+  margin-bottom: 15px; }
+
+.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs button {
+  background: transparent;
+  border: 0;
+  border: 1px solid #eee;
+  border-bottom: 4px solid transparent;
+  padding: 10px 16px 6px;
+  margin-bottom: -4px;
+  outline: 0;
+  color: #575757;
+  width: 50%;
+  font-size: 14px;
+  font-weight: bold; }
+
+.kt-inspect-tabs.kt-gradient-tabs .components-tab-panel__tabs button.active-tab {
+  background: #0085ba;
+  color: white; }
+
+.components-button-group .kt-layout-btn {
+  height: 36px;
+  background: transparent;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  border: 1px solid #eee;
+  padding: 2px;
+  margin-right: 5px;
+  margin-bottom: 5px; }
+
+.components-button-group .kt-layout-btn svg {
+  width: 60px;
+  height: 30px; }
+
+.components-button-group .kt-layout-btn:hover, .components-button-group .kt-layout-btn.is-primary, .components-button-group .kt-layout-btn:focus:not(:disabled):not([aria-disabled=true]) {
+  border-color: #ddd;
+  background: transparent;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.components-button-group .kt-layout-btn:hover svg rect {
+  fill: #9EAAB5; }
+
+.components-button-group .kt-layout-btn.is-primary svg rect {
+  fill: #738495; }
+
+.editor-block-list__block[data-type="kadence/rowlayout"].is-selected .editor-block-list__block-edit .wp-block-kadence-rowlayout-handler-top,
+.editor-block-list__block[data-type="kadence/rowlayout"].is-selected .editor-block-list__block-edit .wp-block-kadence-rowlayout-handler-bottom {
+  display: block; }
+
+.wp-block-kadence-rowlayout-handler-bottom {
+  bottom: 0px !important; }
+
+.wp-block-kadence-rowlayout-handler-top {
+  top: 0px !important; }
+
+.wp-block-kadence-rowlayout-handler-top,
+.wp-block-kadence-rowlayout-handler-bottom {
+  display: none;
+  border-radius: 0;
+  border: 0;
+  min-height: 20px;
+  width: 100%;
+  height: 100% !important;
+  position: absolute;
+  background: transparent;
+  padding: 0;
+  z-index: 1000;
+  cursor: se-resize;
+  left: 0px;
+  margin-left: 0px; }
+
+.kt-padding-resize-box {
+  z-index: 10; }
+
+.kt-row-padding {
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  -ms-flex-pack: center;
+      justify-content: center;
+  -ms-flex-align: center;
+      align-items: center;
+  color: #777;
+  opacity: 0;
+  -webkit-transition: opacity .3s ease;
+  -o-transition: opacity .3s ease;
+  transition: opacity .3s ease; }
+  .kt-row-padding span {
+    background: rgba(255, 255, 255, 0.7);
+    padding: 0 6px; }
+
+.kt-row-has-bg .kt-row-padding {
+  color: #000; }
+
+.is-selected .kt-padding-resize-box:hover .kt-row-padding {
+  opacity: 1; }
+
+.kadence-inner-column-inner {
+  border: 0 solid transparent; }
+
+.wp-block-kadence-rowlayout .editor-block-list__layout {
+  margin-left: 0;
+  margin-right: 0; }
+  .wp-block-kadence-rowlayout .editor-block-list__layout:first-child {
+    margin-left: -14px; }
+  .wp-block-kadence-rowlayout .editor-block-list__layout:last-child {
+    margin-right: -14px; }
+  .wp-block-kadence-rowlayout .editor-block-list__layout .editor-block-list__block {
+    max-width: none !important; }
+
+.editor-block-list__block[data-type="kadence/rowlayout"] {
+  clear: both; }
+
+.editor-block-list__block[data-align=center][data-type="kadence/rowlayout"] {
+  text-align: inherit; }
+
+.editor-block-list__block[data-type="kadence/column"] > .editor-block-contextual-toolbar {
+  top: 38px;
+  -webkit-transform: translateY(-38px);
+      -ms-transform: translateY(-38px);
+          transform: translateY(-38px);
+  margin-left: -29px;
+  margin-right: -29px; }
+
+.editor-block-list__block[data-type="kadence/column"] > .editor-block-list__insertion-point {
+  top: 0;
+  margin-top: 0; }
+
+.editor-block-list__block[data-align="full"] .wp-block-kadence-rowlayout > .editor-inner-blocks > .editor-block-list__layout:first-child {
+  margin-left: 30px; }
+
+.editor-block-list__block[data-align="full"] .wp-block-kadence-rowlayout > .editor-inner-blocks > .editor-block-list__layout:last-child {
+  margin-right: 30px; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-middle {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-middle > .innerblocks-wrap {
+  width: 100%; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-bottom {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-bottom > .innerblocks-wrap {
+  width: 100%; }
+
+.editor-block-list__layout .editor-block-list__block[data-type="kadence/column"] > .editor-block-list__block-edit {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0.1px;
+  padding-bottom: 0.1px; }
+  .editor-block-list__layout .editor-block-list__block[data-type="kadence/column"] > .editor-block-list__block-edit > div:not(.editor-block-contextual-toolbar) {
+    width: 100%; }
+  .editor-block-list__layout .editor-block-list__block[data-type="kadence/column"] > .editor-block-list__block-edit > .editor-block-contextual-toolbar {
+    position: absolute;
+    top: 0;
+    -webkit-transform: translateY(-39px);
+        -ms-transform: translateY(-39px);
+            transform: translateY(-39px); }
+
+.wp-block-kadence-rowlayout > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] > .editor-block-list__block-edit:before {
+  bottom: 0;
+  top: 0; }
+
+.kt-row-has-bg .innerblocks-wrap {
+  padding-left: 15px;
+  padding-right: 15px; }
+
+.editor-block-list__block[data-align="full"] .wp-block-kadence-rowlayout {
+  padding-left: 15px;
+  padding-right: 15px; }
+
+.wp-block-kadence-rowlayout {
+  display: block;
+  position: relative; }
+  .wp-block-kadence-rowlayout > .innerblocks-wrap {
+    z-index: 10;
+    position: relative;
+    margin: 0 auto;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: column;
+        flex-direction: column; }
+    .wp-block-kadence-rowlayout > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout {
+      display: -ms-flexbox;
+      display: flex;
+      -ms-flex-wrap: nowrap;
+          flex-wrap: nowrap;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+      margin-left: -14px;
+      margin-right: -14px; }
+      .wp-block-kadence-rowlayout > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-direction: column;
+            flex-direction: column;
+        -ms-flex: 1;
+            flex: 1;
+        min-width: 0;
+        word-break: break-word;
+        overflow-wrap: break-word;
+        max-width: none;
+        margin-top: -14px;
+        margin-bottom: -14px; }
+        .wp-block-kadence-rowlayout > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] .editor-block-list__block-edit {
+          -ms-flex-preferred-size: 100%;
+              flex-basis: 100%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-left-golden > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child {
+  -ms-flex: 0 1 66.67%;
+      flex: 0 1 66.67%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-left-golden > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  -ms-flex: 0 1 33.33%;
+      flex: 0 1 33.33%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-right-golden > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child {
+  -ms-flex: 0 1 33.33%;
+      flex: 0 1 33.33%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-right-golden > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  -ms-flex: 0 1 66.67%;
+      flex: 0 1 66.67%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-row > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout {
+  -ms-flex-direction: column;
+      flex-direction: column; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-row > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: none;
+      flex: none;
+  width: 100%;
+  margin-right: 0;
+  margin-bottom: 30px; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-left-half > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: 0 1 25%;
+      flex: 0 1 25%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-left-half > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child {
+  -ms-flex: 0 1 50%;
+      flex: 0 1 50%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-right-half > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: 0 1 25%;
+      flex: 0 1 25%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-right-half > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  -ms-flex: 0 1 50%;
+      flex: 0 1 50%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-half > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: 0 1 50%;
+      flex: 0 1 50%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-half > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child {
+  -ms-flex: 0 1 25%;
+      flex: 0 1 25%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-half > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  -ms-flex: 0 1 25%;
+      flex: 0 1 25%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-wide > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: 0 1 60%;
+      flex: 0 1 60%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-wide > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child {
+  -ms-flex: 0 1 20%;
+      flex: 0 1 20%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-wide > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  -ms-flex: 0 1 20%;
+      flex: 0 1 20%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-exwide > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: 0 1 70%;
+      flex: 0 1 70%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-exwide > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child {
+  -ms-flex: 0 1 15%;
+      flex: 0 1 15%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-center-exwide > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  -ms-flex: 0 1 15%;
+      flex: 0 1 15%; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-left-forty > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: 1;
+      flex: 1; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-left-forty > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child {
+  -ms-flex: 2;
+      flex: 2; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-right-forty > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  -ms-flex: 1;
+      flex: 1; }
+
+.wp-block-kadence-rowlayout.kt-row-layout-right-forty > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  -ms-flex: 2;
+      flex: 2; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-middle > .innerblocks-wrap {
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-bottom > .innerblocks-wrap {
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-middle > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] > .editor-block-list__block-edit {
+  -ms-flex-align: center;
+      align-items: center;
+  display: -ms-flexbox;
+  display: flex; }
+
+.wp-block-kadence-rowlayout.kt-row-valign-bottom > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] > .editor-block-list__block-edit {
+  -ms-flex-align: end;
+      align-items: flex-end;
+  display: -ms-flexbox;
+  display: flex; }
+
+.kt-row-layout-overlay, .kt-row-layout-background {
+  top: -16px;
+  bottom: -16px;
+  left: 0;
+  position: absolute;
+  height: auto;
+  width: 100%; }
+
+.kt-select-layout-title {
+  text-transform: uppercase;
+  padding-bottom: 10px;
+  font-size: 16px; }
+
+.kt-select-layout {
+  padding: 30px;
+  border: 2px dashed #ddd;
+  text-align: center;
+  position: relative;
+  z-index: 10; }
+  .kt-select-layout .components-button-group .kt-layout-btn {
+    height: 49px;
+    border: 0;
+    margin-right: 10px;
+    margin-bottom: 10px; }
+    .kt-select-layout .components-button-group .kt-layout-btn svg {
+      width: 90px;
+      height: 45px; }
+
+.kadence-column {
+  width: 100%; }
+
+.kt-gutter-default > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  margin-right: 30px; }
+
+.kt-gutter-skinny > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  margin-right: 10px; }
+
+.kt-gutter-narrow > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  margin-right: 20px; }
+
+.kt-gutter-wide > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  margin-right: 40px; }
+
+.kt-gutter-wider > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  margin-right: 60px; }
+
+.kt-gutter-widest > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+  margin-right: 80px; }
+
+.wp-block-kadence-rowlayout:not(.kt-gutter-none) > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:last-child {
+  margin-right: 0px; }
+
+.editor-row-first-column__resizer {
+  position: absolute !important;
+  left: 0;
+  height: 100% !important;
+  background: transparent;
+  top: 0; }
+  .editor-row-first-column__resizer .components-resizable-box__handle {
+    z-index: 1000; }
+  .editor-row-first-column__resizer .components-resizable-box__handle:before {
+    top: 50%;
+    position: absolute;
+    left: 50%;
+    -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+            transform: translateX(-50%);
+    margin-top: -8px;
+    z-index: 2; }
+  .editor-row-first-column__resizer .components-resizable-box__handle:after {
+    background: rgba(0, 0, 0, 0.1);
+    border: none;
+    border-radius: 0;
+    content: "";
+    cursor: inherit;
+    display: block;
+    height: 100%;
+    position: absolute;
+    left: 50%;
+    -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+            transform: translateX(-50%);
+    width: 2px;
+    top: 0; }
+
+.kt-resizeable-column-container {
+  margin-left: -14px;
+  margin-right: -14px;
+  position: absolute !important;
+  height: 100%;
+  width: auto;
+  left: 0;
+  right: 0; }
+
+.kt-block-defaults-modal .kt-inspect-tabs p.kt-measurement-label {
+  color: #23282d;
+  margin: 1em 0;
+  font-weight: bold; }
+
+.wp-block.is-selected[data-type="kadence/rowlayout"] .editor-row-first-column__resizer .left-column-width-size {
+  z-index: 100;
+  opacity: 1; }
+
+.wp-block-kadence-rowlayout:not(.kt-gutter-skinny):not(.kt-gutter-narrow):not(.kt-gutter-none) > .innerblocks-wrap > .kt-resizeable-column-container .editor-row-first-column__resizer .components-resizable-box__handle {
+  width: 30px !important;
+  right: 0 !important;
+  margin-right: -15px;
+  padding: 0; }
+
+.left-column-width-size {
+  right: -10px;
+  padding-right: 10px;
+  margin-left: 0; }
+
+.column-width-size-handle {
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  z-index: -1;
+  width: 70px;
+  height: 40px;
+  color: #222;
+  text-align: center;
+  line-height: 40px;
+  margin-top: -20px; }
+
+.wp-block.is-selected[data-type="kadence/rowlayout"] .editor-row-first-column__resizer .right-column-width-size {
+  z-index: 100;
+  opacity: 1; }
+
+.right-column-width-size {
+  left: 100%;
+  padding-left: 10px;
+  margin-left: -10px; }
+
+.wp-block.is-selected[data-type="kadence/rowlayout"] .editor-row-first-column__resizer .components-resizable-box__handle {
+  display: block; }
+
+@media (max-width: 600px) {
+  .wp-block-kadence-rowlayout > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout {
+    -ms-flex-direction: column;
+        flex-direction: column; }
+  .wp-block-kadence-rowlayout > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"] {
+    -ms-flex: none !important;
+        flex: none !important;
+    width: 100%;
+    margin-right: 0; }
+  .kt-resizeable-column-container {
+    display: none; } }
+
+.editor-block-list__block[data-type="kadence/rowlayout"] > .editor-block-list__block-edit:before {
+  pointer-events: inherit; }
+
+.editor-block-list__block[data-type="kadence/rowlayout"] > .editor-block-list__insertion-point {
+  height: 16px; }
+  .editor-block-list__block[data-type="kadence/rowlayout"] > .editor-block-list__insertion-point .editor-block-list__insertion-point-inserter {
+    height: 16px; }
+
+.editor-block-list__block[data-type="kadence/rowlayout"][data-align=full] > .editor-block-list__block-edit > div > .wp-block-kadence-rowlayout:not(.kt-has-1-columns) > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child > .editor-block-list__block-edit > div > .kadence-column > .kadence-inner-column-inner > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block > .editor-block-mover {
+  left: 1px;
+  top: -34px;
+  width: auto;
+  height: auto;
+  min-height: 0; }
+  .editor-block-list__block[data-type="kadence/rowlayout"][data-align=full] > .editor-block-list__block-edit > div > .wp-block-kadence-rowlayout:not(.kt-has-1-columns) > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child > .editor-block-list__block-edit > div > .kadence-column > .kadence-inner-column-inner > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block > .editor-block-mover .editor-block-mover__control {
+    float: left; }
+
+.editor-block-list__block[data-type="kadence/rowlayout"][data-align=full] > .editor-block-list__block-edit > div > .wp-block-kadence-rowlayout:not(.kt-has-1-columns) > .innerblocks-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-type="kadence/column"]:first-child > .editor-block-list__block-edit > div > .kadence-column > .kadence-inner-column-inner > .editor-inner-blocks > .editor-block-list__layout > .editor-block-list__block.is-selected > .editor-block-mover {
+  top: -70px; }
+
+.wp-block-kadence-rowlayout .editor-block-list__layout .editor-block-list__block {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.wp-block-image img {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.kt-row-layout-overlay, .kt-row-layout-background, .kt-row-layout-bottom-sep, .kt-row-layout-top-sep, .editor-block-list__block[data-type="kadence/rowlayout"] {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-kadence-icon {
+  min-width: 20px;
+  min-height: 10px; }
+
+.rfipbtn, .rfipdropdown {
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+  font-size: 14px;
+  line-height: 1.71429;
+  vertical-align: baseline; }
+
+.rfipbtn, .rfipbtn *, .rfipdropdown, .rfipdropdown * {
+  margin: 0;
+  padding: 0;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box; }
+
+.rfipbtn input, .rfipbtn select, .rfipdropdown input, .rfipdropdown select {
+  font-size: 14px; }
+
+.rfip {
+  position: relative;
+  display: inline-block;
+  margin: 8px;
+  vertical-align: middle; }
+
+.rfipbtn {
+  width: 136px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  min-height: 50px;
+  border-radius: 2px;
+  cursor: pointer;
+  -webkit-transition: border-color .25s,-webkit-box-shadow .25s;
+  transition: border-color .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border-color .25s;
+  transition: box-shadow .25s,border-color .25s;
+  transition: box-shadow .25s,border-color .25s,-webkit-box-shadow .25s;
+  outline: 0 none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
+
+.rfipbtn--open {
+  border-radius: 2px 2px 0 0; }
+
+.rfipbtn__button {
+  width: 48px;
+  margin-left: auto;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: auto;
+  -webkit-transition: background .25s,-webkit-box-shadow .25s;
+  transition: background .25s,-webkit-box-shadow .25s;
+  -o-transition: background .25s,box-shadow .25s;
+  transition: background .25s,box-shadow .25s;
+  transition: background .25s,box-shadow .25s,-webkit-box-shadow .25s; }
+
+.rfipbtn__button i {
+  font-size: 32px;
+  -webkit-transition: -webkit-transform .25s;
+  transition: -webkit-transform .25s;
+  -o-transition: transform .25s;
+  transition: transform .25s;
+  transition: transform .25s, -webkit-transform .25s;
+  transition: transform .25s,-webkit-transform .25s; }
+
+.rfipbtn__button--open i {
+  -webkit-transform: rotate(-180deg);
+  -ms-transform: rotate(-180deg);
+      transform: rotate(-180deg); }
+
+.rfipbtn__current {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -ms-flex: 0 0 86px;
+  flex: 0 0 86px;
+  padding: 2px; }
+
+.rfipbtn--multi {
+  width: 258px; }
+
+.rfipbtn--multi .rfipbtn__current {
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -ms-flex-preferred-size: 212px;
+  flex-basis: 212px;
+  -ms-flex-line-pack: center;
+  align-content: center; }
+
+.rfipbtn--multi .rfipbtn__current, .rfipbtn__icon { }
+
+.rfipbtn__icon {
+  margin: 2px;
+  padding: 0;
+  height: 28px;
+  width: 48px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  border-radius: 2px; }
+
+.rfipbtn__icon--empty {
+  font-size: 14px;
+  line-height: 16px;
+  margin-left: 8px;
+  text-align: center;
+  text-transform: lowercase;
+  font-style: italic; }
+
+.rfipbtn__elm {
+  display: -ms-flexbox;
+  display: flex;
+  height: 28px;
+  width: 28px;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 18px; }
+
+.rfipbtn__elm img, .rfipbtn__elm svg {
+  height: 18px;
+  width: auto; }
+
+.rfipbtn__del {
+  width: 18px;
+  display: -ms-flexbox;
+  display: flex;
+  height: 28px;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: background-color .25s;
+  -o-transition: background-color .25s;
+  transition: background-color .25s;
+  cursor: pointer; }
+
+.rfipcategory {
+  width: 100%;
+  margin: 0 0 8px;
+  position: relative; }
+
+.rfipcategory select {
+  width: 100%;
+  display: block;
+  height: 32px;
+  line-height: 32px;
+  border-radius: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: border .25s,box-shadow .25s;
+  transition: border .25s,box-shadow .25s;
+  transition: border .25s,box-shadow .25s,-webkit-box-shadow .25s;
+  background-color: transparent !important; }
+
+.rfipcategory i {
+  position: absolute;
+  right: 2px;
+  top: 0;
+  font-size: 16px;
+  line-height: 32px;
+  z-index: -1; }
+
+.rfipdropdown {
+  width: 352px;
+  position: absolute;
+  left: 0;
+  margin-top: -1px;
+  z-index: 100000001;
+  border-radius: 0 1px 4px 4px; }
+
+.rfipdropdown__selector {
+  overflow: hidden;
+  padding: 16px; }
+
+.rfipdropdown.fipappear-enter-active .rfipdropdown__selector, .rfipdropdown.fipappear-exit-active .rfipdropdown__selector {
+  -webkit-transition: max-height .3s ease-out,padding .3s ease-out;
+  -o-transition: max-height .3s ease-out,padding .3s ease-out;
+  transition: max-height .3s ease-out,padding .3s ease-out;
+  padding: 16px; }
+
+.rfipicons__pager {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  height: 24px;
+  line-height: 24px;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 8px; }
+
+.rfipicons__num {
+  width: 100px;
+  margin-right: auto; }
+
+.rfipicons__cp {
+  width: 32px;
+  height: 24px;
+  line-height: 24px;
+  text-align: right; }
+
+.rfipicons__cp, .rfipicons__sp, .rfipicons__tp {
+  margin-right: 8px; }
+
+.rfipicons__arrow {
+  margin-left: auto;
+  width: 56px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 24px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
+
+.rfipicons__right {
+  margin-left: auto; }
+
+.rfipicons__left, .rfipicons__right {
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  position: relative;
+  -webkit-transition: background-color .25s,border .25s;
+  -o-transition: background-color .25s,border .25s;
+  transition: background-color .25s,border .25s;
+  outline: 0 none;
+  border-radius: 2px;
+  font-size: 18px; }
+
+.rfipicons__label {
+  height: 22px;
+  width: 22px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  justify-content: center; }
+
+.rfipicons__label img {
+  height: 18px;
+  width: 18px; }
+
+.rfipicons__selector {
+  -ms-flex: 1 1 20%;
+  flex: 1 1 20%;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -ms-flex-pack: start;
+  justify-content: flex-start; }
+
+.rfipicons__ibox, .rfipicons__selector {
+  display: -ms-flexbox;
+  display: flex; }
+
+.rfipicons__ibox {
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  -webkit-transition: background-color .25s,border .25s;
+  -o-transition: background-color .25s,border .25s;
+  transition: background-color .25s,border .25s;
+  border-radius: 2px;
+  outline: 0 none;
+  font-size: 20px; }
+
+.rfipicons__ibox img, .rfipicons__ibox svg {
+  max-height: 24px;
+  width: auto; }
+
+.rfipicons__ibox > * {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+      transform: scale(1);
+  -webkit-transition: -webkit-transform .25s;
+  transition: -webkit-transform .25s;
+  -o-transition: transform .25s;
+  transition: transform .25s;
+  transition: transform .25s, -webkit-transform .25s;
+  transition: transform .25s,-webkit-transform .25s;
+  -webkit-transform-origin: center;
+  -ms-transform-origin: center;
+      transform-origin: center; }
+
+.rfipicons__ibox:hover > * {
+  -webkit-transform: scale(1.8);
+  -ms-transform: scale(1.8);
+      transform: scale(1.8); }
+
+.rfipicons__ibox--error {
+  text-transform: lowercase;
+  font-style: italic; }
+
+.rfipicons__icon {
+  width: 20%;
+  height: 64px;
+  padding: 1px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  cursor: pointer; }
+
+.rfipicons__icon--error {
+  display: block;
+  padding: 16px;
+  text-align: center;
+  font-size: 24px;
+  width: 100%;
+  line-height: 1; }
+
+.rfipsearch {
+  width: 100%;
+  margin: 0 0 8px; }
+
+.rfipsearch input {
+  width: 100%;
+  display: block;
+  height: 32px;
+  line-height: 32px; }
+
+/*!
  * 
  * React FontIconPicker
  * 
@@ -17,12 +1921,4667 @@
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  * 
- */.rfipbtn--green{background-color:#fff;border:1px solid #81c784}.rfipbtn--green:active,.rfipbtn--green:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #66bb6a}.rfipbtn--green .rfipbtn__button{border:0 none transparent;border-left:1px solid #81c784;background-color:#c8e6c9;color:#2e7d32}.rfipbtn--green .rfipbtn__button:hover{background-color:#66bb6a}.rfipbtn--green .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #81c784;box-shadow:inset 0 0 10px 0 #81c784}.rfipbtn--green .rfipbtn__icon{border:1px solid #a5d6a7;color:#2e7d32}.rfipbtn--green .rfipbtn__icon--empty{color:#81c784}.rfipbtn--green .rfipbtn__del{background-color:#a5d6a7}.rfipbtn--green .rfipbtn__del:hover{background-color:#81c784}.rfipbtn--green .rfipbtn__del:active,.rfipbtn--green .rfipbtn__del:focus{outline:1px solid #81c784}.rfipdropdown--green{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #81c784}.rfipdropdown--green input,.rfipdropdown--green select{color:#424242}.rfipdropdown--green .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #66bb6a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--green .rfipcategory select:active,.rfipdropdown--green .rfipcategory select:focus{border-bottom-color:#4caf50;-webkit-box-shadow:0 1px 0 0 #4caf50;box-shadow:0 1px 0 0 #4caf50;outline:0 none}.rfipdropdown--green .rfipicons__cp{border:0 none;border-bottom:1px solid #66bb6a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--green .rfipicons__cp:active,.rfipdropdown--green .rfipicons__cp:focus{border-bottom-color:#4caf50;-webkit-box-shadow:0 1px 0 0 #4caf50;box-shadow:0 1px 0 0 #4caf50;outline:0 none}.rfipdropdown--green .rfipicons__left,.rfipdropdown--green .rfipicons__right{background-color:#a5d6a7;border:1px solid #a5d6a7;color:#2e7d32}.rfipdropdown--green .rfipicons__left:hover,.rfipdropdown--green .rfipicons__right:hover{background-color:#66bb6a;border:1px solid #66bb6a}.rfipdropdown--green .rfipicons__left:active,.rfipdropdown--green .rfipicons__left:focus,.rfipdropdown--green .rfipicons__right:active,.rfipdropdown--green .rfipicons__right:focus{border:1px solid #66bb6a}.rfipdropdown--green .rfipicons__ibox{background-color:#c8e6c9;border:1px solid #c8e6c9;color:#2e7d32}.rfipdropdown--green .rfipicons__ibox:hover{background-color:#66bb6a;border:1px solid #66bb6a}.rfipdropdown--green .rfipicons__ibox:active,.rfipdropdown--green .rfipicons__ibox:focus{border:1px solid #66bb6a}.rfipdropdown--green .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--green .rfipicons__icon--selected .rfipicons__ibox{background-color:#a5d6a7}.rfipdropdown--green .rfipsearch input{border:0 none;border-bottom:1px solid #66bb6a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--green .rfipsearch input:active,.rfipdropdown--green .rfipsearch input:focus{border-bottom-color:#4caf50;-webkit-box-shadow:0 1px 0 0 #4caf50;box-shadow:0 1px 0 0 #4caf50;outline:0 none}.rfipbtn--bluegrey{background-color:#fff;border:1px solid #90a4ae}.rfipbtn--bluegrey:active,.rfipbtn--bluegrey:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #78909c}.rfipbtn--bluegrey .rfipbtn__button{border:0 none transparent;border-left:1px solid #90a4ae;background-color:#cfd8dc;color:#37474f}.rfipbtn--bluegrey .rfipbtn__button:hover{background-color:#78909c}.rfipbtn--bluegrey .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #90a4ae;box-shadow:inset 0 0 10px 0 #90a4ae}.rfipbtn--bluegrey .rfipbtn__icon{border:1px solid #b0bec5;color:#37474f}.rfipbtn--bluegrey .rfipbtn__icon--empty{color:#90a4ae}.rfipbtn--bluegrey .rfipbtn__del{background-color:#b0bec5}.rfipbtn--bluegrey .rfipbtn__del:hover{background-color:#90a4ae}.rfipbtn--bluegrey .rfipbtn__del:active,.rfipbtn--bluegrey .rfipbtn__del:focus{outline:1px solid #90a4ae}.rfipdropdown--bluegrey{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #90a4ae}.rfipdropdown--bluegrey input,.rfipdropdown--bluegrey select{color:#424242}.rfipdropdown--bluegrey .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #78909c;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--bluegrey .rfipcategory select:active,.rfipdropdown--bluegrey .rfipcategory select:focus{border-bottom-color:#607d8b;-webkit-box-shadow:0 1px 0 0 #607d8b;box-shadow:0 1px 0 0 #607d8b;outline:0 none}.rfipdropdown--bluegrey .rfipicons__cp{border:0 none;border-bottom:1px solid #78909c;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--bluegrey .rfipicons__cp:active,.rfipdropdown--bluegrey .rfipicons__cp:focus{border-bottom-color:#607d8b;-webkit-box-shadow:0 1px 0 0 #607d8b;box-shadow:0 1px 0 0 #607d8b;outline:0 none}.rfipdropdown--bluegrey .rfipicons__left,.rfipdropdown--bluegrey .rfipicons__right{background-color:#b0bec5;border:1px solid #b0bec5;color:#37474f}.rfipdropdown--bluegrey .rfipicons__left:hover,.rfipdropdown--bluegrey .rfipicons__right:hover{background-color:#78909c;border:1px solid #78909c}.rfipdropdown--bluegrey .rfipicons__left:active,.rfipdropdown--bluegrey .rfipicons__left:focus,.rfipdropdown--bluegrey .rfipicons__right:active,.rfipdropdown--bluegrey .rfipicons__right:focus{border:1px solid #78909c}.rfipdropdown--bluegrey .rfipicons__ibox{background-color:#cfd8dc;border:1px solid #cfd8dc;color:#37474f}.rfipdropdown--bluegrey .rfipicons__ibox:hover{background-color:#78909c;border:1px solid #78909c}.rfipdropdown--bluegrey .rfipicons__ibox:active,.rfipdropdown--bluegrey .rfipicons__ibox:focus{border:1px solid #78909c}.rfipdropdown--bluegrey .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--bluegrey .rfipicons__icon--selected .rfipicons__ibox{background-color:#b0bec5}.rfipdropdown--bluegrey .rfipsearch input{border:0 none;border-bottom:1px solid #78909c;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--bluegrey .rfipsearch input:active,.rfipdropdown--bluegrey .rfipsearch input:focus{border-bottom-color:#607d8b;-webkit-box-shadow:0 1px 0 0 #607d8b;box-shadow:0 1px 0 0 #607d8b;outline:0 none}.rfipbtn--brown{background-color:#fff;border:1px solid #a1887f}.rfipbtn--brown:active,.rfipbtn--brown:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #8d6e63}.rfipbtn--brown .rfipbtn__button{border:0 none transparent;border-left:1px solid #a1887f;background-color:#d7ccc8;color:#4e342e}.rfipbtn--brown .rfipbtn__button:hover{background-color:#8d6e63}.rfipbtn--brown .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #a1887f;box-shadow:inset 0 0 10px 0 #a1887f}.rfipbtn--brown .rfipbtn__icon{border:1px solid #bcaaa4;color:#4e342e}.rfipbtn--brown .rfipbtn__icon--empty{color:#a1887f}.rfipbtn--brown .rfipbtn__del{background-color:#bcaaa4}.rfipbtn--brown .rfipbtn__del:hover{background-color:#a1887f}.rfipbtn--brown .rfipbtn__del:active,.rfipbtn--brown .rfipbtn__del:focus{outline:1px solid #a1887f}.rfipdropdown--brown{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #a1887f}.rfipdropdown--brown input,.rfipdropdown--brown select{color:#424242}.rfipdropdown--brown .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #8d6e63;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--brown .rfipcategory select:active,.rfipdropdown--brown .rfipcategory select:focus{border-bottom-color:#795548;-webkit-box-shadow:0 1px 0 0 #795548;box-shadow:0 1px 0 0 #795548;outline:0 none}.rfipdropdown--brown .rfipicons__cp{border:0 none;border-bottom:1px solid #8d6e63;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--brown .rfipicons__cp:active,.rfipdropdown--brown .rfipicons__cp:focus{border-bottom-color:#795548;-webkit-box-shadow:0 1px 0 0 #795548;box-shadow:0 1px 0 0 #795548;outline:0 none}.rfipdropdown--brown .rfipicons__left,.rfipdropdown--brown .rfipicons__right{background-color:#bcaaa4;border:1px solid #bcaaa4;color:#4e342e}.rfipdropdown--brown .rfipicons__left:hover,.rfipdropdown--brown .rfipicons__right:hover{background-color:#8d6e63;border:1px solid #8d6e63}.rfipdropdown--brown .rfipicons__left:active,.rfipdropdown--brown .rfipicons__left:focus,.rfipdropdown--brown .rfipicons__right:active,.rfipdropdown--brown .rfipicons__right:focus{border:1px solid #8d6e63}.rfipdropdown--brown .rfipicons__ibox{background-color:#d7ccc8;border:1px solid #d7ccc8;color:#4e342e}.rfipdropdown--brown .rfipicons__ibox:hover{background-color:#8d6e63;border:1px solid #8d6e63}.rfipdropdown--brown .rfipicons__ibox:active,.rfipdropdown--brown .rfipicons__ibox:focus{border:1px solid #8d6e63}.rfipdropdown--brown .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--brown .rfipicons__icon--selected .rfipicons__ibox{background-color:#bcaaa4}.rfipdropdown--brown .rfipsearch input{border:0 none;border-bottom:1px solid #8d6e63;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--brown .rfipsearch input:active,.rfipdropdown--brown .rfipsearch input:focus{border-bottom-color:#795548;-webkit-box-shadow:0 1px 0 0 #795548;box-shadow:0 1px 0 0 #795548;outline:0 none}.rfipbtn--cyan{background-color:#fff;border:1px solid #4dd0e1}.rfipbtn--cyan:active,.rfipbtn--cyan:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #26c6da}.rfipbtn--cyan .rfipbtn__button{border:0 none transparent;border-left:1px solid #4dd0e1;background-color:#b2ebf2;color:#00838f}.rfipbtn--cyan .rfipbtn__button:hover{background-color:#26c6da}.rfipbtn--cyan .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #4dd0e1;box-shadow:inset 0 0 10px 0 #4dd0e1}.rfipbtn--cyan .rfipbtn__icon{border:1px solid #80deea;color:#00838f}.rfipbtn--cyan .rfipbtn__icon--empty{color:#4dd0e1}.rfipbtn--cyan .rfipbtn__del{background-color:#80deea}.rfipbtn--cyan .rfipbtn__del:hover{background-color:#4dd0e1}.rfipbtn--cyan .rfipbtn__del:active,.rfipbtn--cyan .rfipbtn__del:focus{outline:1px solid #4dd0e1}.rfipdropdown--cyan{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #4dd0e1}.rfipdropdown--cyan input,.rfipdropdown--cyan select{color:#424242}.rfipdropdown--cyan .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #26c6da;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--cyan .rfipcategory select:active,.rfipdropdown--cyan .rfipcategory select:focus{border-bottom-color:#00bcd4;-webkit-box-shadow:0 1px 0 0 #00bcd4;box-shadow:0 1px 0 0 #00bcd4;outline:0 none}.rfipdropdown--cyan .rfipicons__cp{border:0 none;border-bottom:1px solid #26c6da;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--cyan .rfipicons__cp:active,.rfipdropdown--cyan .rfipicons__cp:focus{border-bottom-color:#00bcd4;-webkit-box-shadow:0 1px 0 0 #00bcd4;box-shadow:0 1px 0 0 #00bcd4;outline:0 none}.rfipdropdown--cyan .rfipicons__left,.rfipdropdown--cyan .rfipicons__right{background-color:#80deea;border:1px solid #80deea;color:#00838f}.rfipdropdown--cyan .rfipicons__left:hover,.rfipdropdown--cyan .rfipicons__right:hover{background-color:#26c6da;border:1px solid #26c6da}.rfipdropdown--cyan .rfipicons__left:active,.rfipdropdown--cyan .rfipicons__left:focus,.rfipdropdown--cyan .rfipicons__right:active,.rfipdropdown--cyan .rfipicons__right:focus{border:1px solid #26c6da}.rfipdropdown--cyan .rfipicons__ibox{background-color:#b2ebf2;border:1px solid #b2ebf2;color:#00838f}.rfipdropdown--cyan .rfipicons__ibox:hover{background-color:#26c6da;border:1px solid #26c6da}.rfipdropdown--cyan .rfipicons__ibox:active,.rfipdropdown--cyan .rfipicons__ibox:focus{border:1px solid #26c6da}.rfipdropdown--cyan .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--cyan .rfipicons__icon--selected .rfipicons__ibox{background-color:#80deea}.rfipdropdown--cyan .rfipsearch input{border:0 none;border-bottom:1px solid #26c6da;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--cyan .rfipsearch input:active,.rfipdropdown--cyan .rfipsearch input:focus{border-bottom-color:#00bcd4;-webkit-box-shadow:0 1px 0 0 #00bcd4;box-shadow:0 1px 0 0 #00bcd4;outline:0 none}.rfipbtn--deeporange{background-color:#fff;border:1px solid #ff8a65}.rfipbtn--deeporange:active,.rfipbtn--deeporange:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #ff7043}.rfipbtn--deeporange .rfipbtn__button{border:0 none transparent;border-left:1px solid #ff8a65;background-color:#ffccbc;color:#d84315}.rfipbtn--deeporange .rfipbtn__button:hover{background-color:#ff7043}.rfipbtn--deeporange .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #ff8a65;box-shadow:inset 0 0 10px 0 #ff8a65}.rfipbtn--deeporange .rfipbtn__icon{border:1px solid #ffab91;color:#d84315}.rfipbtn--deeporange .rfipbtn__icon--empty{color:#ff8a65}.rfipbtn--deeporange .rfipbtn__del{background-color:#ffab91}.rfipbtn--deeporange .rfipbtn__del:hover{background-color:#ff8a65}.rfipbtn--deeporange .rfipbtn__del:active,.rfipbtn--deeporange .rfipbtn__del:focus{outline:1px solid #ff8a65}.rfipdropdown--deeporange{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #ff8a65}.rfipdropdown--deeporange input,.rfipdropdown--deeporange select{color:#424242}.rfipdropdown--deeporange .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #ff7043;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--deeporange .rfipcategory select:active,.rfipdropdown--deeporange .rfipcategory select:focus{border-bottom-color:#ff5722;-webkit-box-shadow:0 1px 0 0 #ff5722;box-shadow:0 1px 0 0 #ff5722;outline:0 none}.rfipdropdown--deeporange .rfipicons__cp{border:0 none;border-bottom:1px solid #ff7043;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--deeporange .rfipicons__cp:active,.rfipdropdown--deeporange .rfipicons__cp:focus{border-bottom-color:#ff5722;-webkit-box-shadow:0 1px 0 0 #ff5722;box-shadow:0 1px 0 0 #ff5722;outline:0 none}.rfipdropdown--deeporange .rfipicons__left,.rfipdropdown--deeporange .rfipicons__right{background-color:#ffab91;border:1px solid #ffab91;color:#d84315}.rfipdropdown--deeporange .rfipicons__left:hover,.rfipdropdown--deeporange .rfipicons__right:hover{background-color:#ff7043;border:1px solid #ff7043}.rfipdropdown--deeporange .rfipicons__left:active,.rfipdropdown--deeporange .rfipicons__left:focus,.rfipdropdown--deeporange .rfipicons__right:active,.rfipdropdown--deeporange .rfipicons__right:focus{border:1px solid #ff7043}.rfipdropdown--deeporange .rfipicons__ibox{background-color:#ffccbc;border:1px solid #ffccbc;color:#d84315}.rfipdropdown--deeporange .rfipicons__ibox:hover{background-color:#ff7043;border:1px solid #ff7043}.rfipdropdown--deeporange .rfipicons__ibox:active,.rfipdropdown--deeporange .rfipicons__ibox:focus{border:1px solid #ff7043}.rfipdropdown--deeporange .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--deeporange .rfipicons__icon--selected .rfipicons__ibox{background-color:#ffab91}.rfipdropdown--deeporange .rfipsearch input{border:0 none;border-bottom:1px solid #ff7043;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--deeporange .rfipsearch input:active,.rfipdropdown--deeporange .rfipsearch input:focus{border-bottom-color:#ff5722;-webkit-box-shadow:0 1px 0 0 #ff5722;box-shadow:0 1px 0 0 #ff5722;outline:0 none}.rfipbtn--deeppurple{background-color:#fff;border:1px solid #9575cd}.rfipbtn--deeppurple:active,.rfipbtn--deeppurple:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #7e57c2}.rfipbtn--deeppurple .rfipbtn__button{border:0 none transparent;border-left:1px solid #9575cd;background-color:#d1c4e9;color:#4527a0}.rfipbtn--deeppurple .rfipbtn__button:hover{background-color:#7e57c2}.rfipbtn--deeppurple .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #9575cd;box-shadow:inset 0 0 10px 0 #9575cd}.rfipbtn--deeppurple .rfipbtn__icon{border:1px solid #b39ddb;color:#4527a0}.rfipbtn--deeppurple .rfipbtn__icon--empty{color:#9575cd}.rfipbtn--deeppurple .rfipbtn__del{background-color:#b39ddb}.rfipbtn--deeppurple .rfipbtn__del:hover{background-color:#9575cd}.rfipbtn--deeppurple .rfipbtn__del:active,.rfipbtn--deeppurple .rfipbtn__del:focus{outline:1px solid #9575cd}.rfipdropdown--deeppurple{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #9575cd}.rfipdropdown--deeppurple input,.rfipdropdown--deeppurple select{color:#424242}.rfipdropdown--deeppurple .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #7e57c2;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--deeppurple .rfipcategory select:active,.rfipdropdown--deeppurple .rfipcategory select:focus{border-bottom-color:#673ab7;-webkit-box-shadow:0 1px 0 0 #673ab7;box-shadow:0 1px 0 0 #673ab7;outline:0 none}.rfipdropdown--deeppurple .rfipicons__cp{border:0 none;border-bottom:1px solid #7e57c2;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--deeppurple .rfipicons__cp:active,.rfipdropdown--deeppurple .rfipicons__cp:focus{border-bottom-color:#673ab7;-webkit-box-shadow:0 1px 0 0 #673ab7;box-shadow:0 1px 0 0 #673ab7;outline:0 none}.rfipdropdown--deeppurple .rfipicons__left,.rfipdropdown--deeppurple .rfipicons__right{background-color:#b39ddb;border:1px solid #b39ddb;color:#4527a0}.rfipdropdown--deeppurple .rfipicons__left:hover,.rfipdropdown--deeppurple .rfipicons__right:hover{background-color:#7e57c2;border:1px solid #7e57c2}.rfipdropdown--deeppurple .rfipicons__left:active,.rfipdropdown--deeppurple .rfipicons__left:focus,.rfipdropdown--deeppurple .rfipicons__right:active,.rfipdropdown--deeppurple .rfipicons__right:focus{border:1px solid #7e57c2}.rfipdropdown--deeppurple .rfipicons__ibox{background-color:#d1c4e9;border:1px solid #d1c4e9;color:#4527a0}.rfipdropdown--deeppurple .rfipicons__ibox:hover{background-color:#7e57c2;border:1px solid #7e57c2}.rfipdropdown--deeppurple .rfipicons__ibox:active,.rfipdropdown--deeppurple .rfipicons__ibox:focus{border:1px solid #7e57c2}.rfipdropdown--deeppurple .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--deeppurple .rfipicons__icon--selected .rfipicons__ibox{background-color:#b39ddb}.rfipdropdown--deeppurple .rfipsearch input{border:0 none;border-bottom:1px solid #7e57c2;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--deeppurple .rfipsearch input:active,.rfipdropdown--deeppurple .rfipsearch input:focus{border-bottom-color:#673ab7;-webkit-box-shadow:0 1px 0 0 #673ab7;box-shadow:0 1px 0 0 #673ab7;outline:0 none}.rfipbtn--default{background-color:#fff;border:1px solid #e0e0e0}.rfipbtn--default:active,.rfipbtn--default:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #bdbdbd}.rfipbtn--default .rfipbtn__button{border:0 none transparent;border-left:1px solid #e0e0e0;background-color:#f5f5f5;color:#424242}.rfipbtn--default .rfipbtn__button:hover{background-color:#bdbdbd}.rfipbtn--default .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #e0e0e0;box-shadow:inset 0 0 10px 0 #e0e0e0}.rfipbtn--default .rfipbtn__icon{border:1px solid #eee;color:#424242}.rfipbtn--default .rfipbtn__icon--empty{color:#e0e0e0}.rfipbtn--default .rfipbtn__del{background-color:#eee}.rfipbtn--default .rfipbtn__del:hover{background-color:#e0e0e0}.rfipbtn--default .rfipbtn__del:active,.rfipbtn--default .rfipbtn__del:focus{outline:1px solid #e0e0e0}.rfipdropdown--default{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #e0e0e0}.rfipdropdown--default input,.rfipdropdown--default select{color:#424242}.rfipdropdown--default .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #bdbdbd;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--default .rfipcategory select:active,.rfipdropdown--default .rfipcategory select:focus{border-bottom-color:#9e9e9e;-webkit-box-shadow:0 1px 0 0 #9e9e9e;box-shadow:0 1px 0 0 #9e9e9e;outline:0 none}.rfipdropdown--default .rfipicons__cp{border:0 none;border-bottom:1px solid #bdbdbd;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--default .rfipicons__cp:active,.rfipdropdown--default .rfipicons__cp:focus{border-bottom-color:#9e9e9e;-webkit-box-shadow:0 1px 0 0 #9e9e9e;box-shadow:0 1px 0 0 #9e9e9e;outline:0 none}.rfipdropdown--default .rfipicons__left,.rfipdropdown--default .rfipicons__right{background-color:#eee;border:1px solid #eee;color:#424242}.rfipdropdown--default .rfipicons__left:hover,.rfipdropdown--default .rfipicons__right:hover{background-color:#bdbdbd;border:1px solid #bdbdbd}.rfipdropdown--default .rfipicons__left:active,.rfipdropdown--default .rfipicons__left:focus,.rfipdropdown--default .rfipicons__right:active,.rfipdropdown--default .rfipicons__right:focus{border:1px solid #bdbdbd}.rfipdropdown--default .rfipicons__ibox{background-color:#f5f5f5;border:1px solid #f5f5f5;color:#424242}.rfipdropdown--default .rfipicons__ibox:hover{background-color:#bdbdbd;border:1px solid #bdbdbd}.rfipdropdown--default .rfipicons__ibox:active,.rfipdropdown--default .rfipicons__ibox:focus{border:1px solid #bdbdbd}.rfipdropdown--default .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--default .rfipicons__icon--selected .rfipicons__ibox{background-color:#eee}.rfipdropdown--default .rfipsearch input{border:0 none;border-bottom:1px solid #bdbdbd;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--default .rfipsearch input:active,.rfipdropdown--default .rfipsearch input:focus{border-bottom-color:#9e9e9e;-webkit-box-shadow:0 1px 0 0 #9e9e9e;box-shadow:0 1px 0 0 #9e9e9e;outline:0 none}.rfipbtn--blue{background-color:#fff;border:1px solid #64b5f6}.rfipbtn--blue:active,.rfipbtn--blue:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #42a5f5}.rfipbtn--blue .rfipbtn__button{border:0 none transparent;border-left:1px solid #64b5f6;background-color:#bbdefb;color:#1565c0}.rfipbtn--blue .rfipbtn__button:hover{background-color:#42a5f5}.rfipbtn--blue .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #64b5f6;box-shadow:inset 0 0 10px 0 #64b5f6}.rfipbtn--blue .rfipbtn__icon{border:1px solid #90caf9;color:#1565c0}.rfipbtn--blue .rfipbtn__icon--empty{color:#64b5f6}.rfipbtn--blue .rfipbtn__del{background-color:#90caf9}.rfipbtn--blue .rfipbtn__del:hover{background-color:#64b5f6}.rfipbtn--blue .rfipbtn__del:active,.rfipbtn--blue .rfipbtn__del:focus{outline:1px solid #64b5f6}.rfipdropdown--blue{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #64b5f6}.rfipdropdown--blue input,.rfipdropdown--blue select{color:#424242}.rfipdropdown--blue .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #42a5f5;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--blue .rfipcategory select:active,.rfipdropdown--blue .rfipcategory select:focus{border-bottom-color:#2196f3;-webkit-box-shadow:0 1px 0 0 #2196f3;box-shadow:0 1px 0 0 #2196f3;outline:0 none}.rfipdropdown--blue .rfipicons__cp{border:0 none;border-bottom:1px solid #42a5f5;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--blue .rfipicons__cp:active,.rfipdropdown--blue .rfipicons__cp:focus{border-bottom-color:#2196f3;-webkit-box-shadow:0 1px 0 0 #2196f3;box-shadow:0 1px 0 0 #2196f3;outline:0 none}.rfipdropdown--blue .rfipicons__left,.rfipdropdown--blue .rfipicons__right{background-color:#90caf9;border:1px solid #90caf9;color:#1565c0}.rfipdropdown--blue .rfipicons__left:hover,.rfipdropdown--blue .rfipicons__right:hover{background-color:#42a5f5;border:1px solid #42a5f5}.rfipdropdown--blue .rfipicons__left:active,.rfipdropdown--blue .rfipicons__left:focus,.rfipdropdown--blue .rfipicons__right:active,.rfipdropdown--blue .rfipicons__right:focus{border:1px solid #42a5f5}.rfipdropdown--blue .rfipicons__ibox{background-color:#bbdefb;border:1px solid #bbdefb;color:#1565c0}.rfipdropdown--blue .rfipicons__ibox:hover{background-color:#42a5f5;border:1px solid #42a5f5}.rfipdropdown--blue .rfipicons__ibox:active,.rfipdropdown--blue .rfipicons__ibox:focus{border:1px solid #42a5f5}.rfipdropdown--blue .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--blue .rfipicons__icon--selected .rfipicons__ibox{background-color:#90caf9}.rfipdropdown--blue .rfipsearch input{border:0 none;border-bottom:1px solid #42a5f5;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--blue .rfipsearch input:active,.rfipdropdown--blue .rfipsearch input:focus{border-bottom-color:#2196f3;-webkit-box-shadow:0 1px 0 0 #2196f3;box-shadow:0 1px 0 0 #2196f3;outline:0 none}.rfipbtn--indigo{background-color:#fff;border:1px solid #7986cb}.rfipbtn--indigo:active,.rfipbtn--indigo:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #5c6bc0}.rfipbtn--indigo .rfipbtn__button{border:0 none transparent;border-left:1px solid #7986cb;background-color:#c5cae9;color:#283593}.rfipbtn--indigo .rfipbtn__button:hover{background-color:#5c6bc0}.rfipbtn--indigo .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #7986cb;box-shadow:inset 0 0 10px 0 #7986cb}.rfipbtn--indigo .rfipbtn__icon{border:1px solid #9fa8da;color:#283593}.rfipbtn--indigo .rfipbtn__icon--empty{color:#7986cb}.rfipbtn--indigo .rfipbtn__del{background-color:#9fa8da}.rfipbtn--indigo .rfipbtn__del:hover{background-color:#7986cb}.rfipbtn--indigo .rfipbtn__del:active,.rfipbtn--indigo .rfipbtn__del:focus{outline:1px solid #7986cb}.rfipdropdown--indigo{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #7986cb}.rfipdropdown--indigo input,.rfipdropdown--indigo select{color:#424242}.rfipdropdown--indigo .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #5c6bc0;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--indigo .rfipcategory select:active,.rfipdropdown--indigo .rfipcategory select:focus{border-bottom-color:#3f51b5;-webkit-box-shadow:0 1px 0 0 #3f51b5;box-shadow:0 1px 0 0 #3f51b5;outline:0 none}.rfipdropdown--indigo .rfipicons__cp{border:0 none;border-bottom:1px solid #5c6bc0;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--indigo .rfipicons__cp:active,.rfipdropdown--indigo .rfipicons__cp:focus{border-bottom-color:#3f51b5;-webkit-box-shadow:0 1px 0 0 #3f51b5;box-shadow:0 1px 0 0 #3f51b5;outline:0 none}.rfipdropdown--indigo .rfipicons__left,.rfipdropdown--indigo .rfipicons__right{background-color:#9fa8da;border:1px solid #9fa8da;color:#283593}.rfipdropdown--indigo .rfipicons__left:hover,.rfipdropdown--indigo .rfipicons__right:hover{background-color:#5c6bc0;border:1px solid #5c6bc0}.rfipdropdown--indigo .rfipicons__left:active,.rfipdropdown--indigo .rfipicons__left:focus,.rfipdropdown--indigo .rfipicons__right:active,.rfipdropdown--indigo .rfipicons__right:focus{border:1px solid #5c6bc0}.rfipdropdown--indigo .rfipicons__ibox{background-color:#c5cae9;border:1px solid #c5cae9;color:#283593}.rfipdropdown--indigo .rfipicons__ibox:hover{background-color:#5c6bc0;border:1px solid #5c6bc0}.rfipdropdown--indigo .rfipicons__ibox:active,.rfipdropdown--indigo .rfipicons__ibox:focus{border:1px solid #5c6bc0}.rfipdropdown--indigo .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--indigo .rfipicons__icon--selected .rfipicons__ibox{background-color:#9fa8da}.rfipdropdown--indigo .rfipsearch input{border:0 none;border-bottom:1px solid #5c6bc0;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--indigo .rfipsearch input:active,.rfipdropdown--indigo .rfipsearch input:focus{border-bottom-color:#3f51b5;-webkit-box-shadow:0 1px 0 0 #3f51b5;box-shadow:0 1px 0 0 #3f51b5;outline:0 none}.rfipbtn--lightblue{background-color:#fff;border:1px solid #4fc3f7}.rfipbtn--lightblue:active,.rfipbtn--lightblue:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #29b6f6}.rfipbtn--lightblue .rfipbtn__button{border:0 none transparent;border-left:1px solid #4fc3f7;background-color:#b3e5fc;color:#0277bd}.rfipbtn--lightblue .rfipbtn__button:hover{background-color:#29b6f6}.rfipbtn--lightblue .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #4fc3f7;box-shadow:inset 0 0 10px 0 #4fc3f7}.rfipbtn--lightblue .rfipbtn__icon{border:1px solid #81d4fa;color:#0277bd}.rfipbtn--lightblue .rfipbtn__icon--empty{color:#4fc3f7}.rfipbtn--lightblue .rfipbtn__del{background-color:#81d4fa}.rfipbtn--lightblue .rfipbtn__del:hover{background-color:#4fc3f7}.rfipbtn--lightblue .rfipbtn__del:active,.rfipbtn--lightblue .rfipbtn__del:focus{outline:1px solid #4fc3f7}.rfipdropdown--lightblue{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #4fc3f7}.rfipdropdown--lightblue input,.rfipdropdown--lightblue select{color:#424242}.rfipdropdown--lightblue .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #29b6f6;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--lightblue .rfipcategory select:active,.rfipdropdown--lightblue .rfipcategory select:focus{border-bottom-color:#03a9f4;-webkit-box-shadow:0 1px 0 0 #03a9f4;box-shadow:0 1px 0 0 #03a9f4;outline:0 none}.rfipdropdown--lightblue .rfipicons__cp{border:0 none;border-bottom:1px solid #29b6f6;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--lightblue .rfipicons__cp:active,.rfipdropdown--lightblue .rfipicons__cp:focus{border-bottom-color:#03a9f4;-webkit-box-shadow:0 1px 0 0 #03a9f4;box-shadow:0 1px 0 0 #03a9f4;outline:0 none}.rfipdropdown--lightblue .rfipicons__left,.rfipdropdown--lightblue .rfipicons__right{background-color:#81d4fa;border:1px solid #81d4fa;color:#0277bd}.rfipdropdown--lightblue .rfipicons__left:hover,.rfipdropdown--lightblue .rfipicons__right:hover{background-color:#29b6f6;border:1px solid #29b6f6}.rfipdropdown--lightblue .rfipicons__left:active,.rfipdropdown--lightblue .rfipicons__left:focus,.rfipdropdown--lightblue .rfipicons__right:active,.rfipdropdown--lightblue .rfipicons__right:focus{border:1px solid #29b6f6}.rfipdropdown--lightblue .rfipicons__ibox{background-color:#b3e5fc;border:1px solid #b3e5fc;color:#0277bd}.rfipdropdown--lightblue .rfipicons__ibox:hover{background-color:#29b6f6;border:1px solid #29b6f6}.rfipdropdown--lightblue .rfipicons__ibox:active,.rfipdropdown--lightblue .rfipicons__ibox:focus{border:1px solid #29b6f6}.rfipdropdown--lightblue .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--lightblue .rfipicons__icon--selected .rfipicons__ibox{background-color:#81d4fa}.rfipdropdown--lightblue .rfipsearch input{border:0 none;border-bottom:1px solid #29b6f6;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--lightblue .rfipsearch input:active,.rfipdropdown--lightblue .rfipsearch input:focus{border-bottom-color:#03a9f4;-webkit-box-shadow:0 1px 0 0 #03a9f4;box-shadow:0 1px 0 0 #03a9f4;outline:0 none}.rfipbtn--pink{background-color:#fff;border:1px solid #f06292}.rfipbtn--pink:active,.rfipbtn--pink:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #ec407a}.rfipbtn--pink .rfipbtn__button{border:0 none transparent;border-left:1px solid #f06292;background-color:#f8bbd0;color:#ad1457}.rfipbtn--pink .rfipbtn__button:hover{background-color:#ec407a}.rfipbtn--pink .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #f06292;box-shadow:inset 0 0 10px 0 #f06292}.rfipbtn--pink .rfipbtn__icon{border:1px solid #f48fb1;color:#ad1457}.rfipbtn--pink .rfipbtn__icon--empty{color:#f06292}.rfipbtn--pink .rfipbtn__del{background-color:#f48fb1}.rfipbtn--pink .rfipbtn__del:hover{background-color:#f06292}.rfipbtn--pink .rfipbtn__del:active,.rfipbtn--pink .rfipbtn__del:focus{outline:1px solid #f06292}.rfipdropdown--pink{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #f06292}.rfipdropdown--pink input,.rfipdropdown--pink select{color:#424242}.rfipdropdown--pink .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #ec407a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--pink .rfipcategory select:active,.rfipdropdown--pink .rfipcategory select:focus{border-bottom-color:#e91e63;-webkit-box-shadow:0 1px 0 0 #e91e63;box-shadow:0 1px 0 0 #e91e63;outline:0 none}.rfipdropdown--pink .rfipicons__cp{border:0 none;border-bottom:1px solid #ec407a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--pink .rfipicons__cp:active,.rfipdropdown--pink .rfipicons__cp:focus{border-bottom-color:#e91e63;-webkit-box-shadow:0 1px 0 0 #e91e63;box-shadow:0 1px 0 0 #e91e63;outline:0 none}.rfipdropdown--pink .rfipicons__left,.rfipdropdown--pink .rfipicons__right{background-color:#f48fb1;border:1px solid #f48fb1;color:#ad1457}.rfipdropdown--pink .rfipicons__left:hover,.rfipdropdown--pink .rfipicons__right:hover{background-color:#ec407a;border:1px solid #ec407a}.rfipdropdown--pink .rfipicons__left:active,.rfipdropdown--pink .rfipicons__left:focus,.rfipdropdown--pink .rfipicons__right:active,.rfipdropdown--pink .rfipicons__right:focus{border:1px solid #ec407a}.rfipdropdown--pink .rfipicons__ibox{background-color:#f8bbd0;border:1px solid #f8bbd0;color:#ad1457}.rfipdropdown--pink .rfipicons__ibox:hover{background-color:#ec407a;border:1px solid #ec407a}.rfipdropdown--pink .rfipicons__ibox:active,.rfipdropdown--pink .rfipicons__ibox:focus{border:1px solid #ec407a}.rfipdropdown--pink .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--pink .rfipicons__icon--selected .rfipicons__ibox{background-color:#f48fb1}.rfipdropdown--pink .rfipsearch input{border:0 none;border-bottom:1px solid #ec407a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--pink .rfipsearch input:active,.rfipdropdown--pink .rfipsearch input:focus{border-bottom-color:#e91e63;-webkit-box-shadow:0 1px 0 0 #e91e63;box-shadow:0 1px 0 0 #e91e63;outline:0 none}.rfipbtn--orange{background-color:#fff;border:1px solid #ffb74d}.rfipbtn--orange:active,.rfipbtn--orange:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #ffa726}.rfipbtn--orange .rfipbtn__button{border:0 none transparent;border-left:1px solid #ffb74d;background-color:#ffe0b2;color:#ef6c00}.rfipbtn--orange .rfipbtn__button:hover{background-color:#ffa726}.rfipbtn--orange .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #ffb74d;box-shadow:inset 0 0 10px 0 #ffb74d}.rfipbtn--orange .rfipbtn__icon{border:1px solid #ffcc80;color:#ef6c00}.rfipbtn--orange .rfipbtn__icon--empty{color:#ffb74d}.rfipbtn--orange .rfipbtn__del{background-color:#ffcc80}.rfipbtn--orange .rfipbtn__del:hover{background-color:#ffb74d}.rfipbtn--orange .rfipbtn__del:active,.rfipbtn--orange .rfipbtn__del:focus{outline:1px solid #ffb74d}.rfipdropdown--orange{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #ffb74d}.rfipdropdown--orange input,.rfipdropdown--orange select{color:#424242}.rfipdropdown--orange .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #ffa726;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--orange .rfipcategory select:active,.rfipdropdown--orange .rfipcategory select:focus{border-bottom-color:#ff9800;-webkit-box-shadow:0 1px 0 0 #ff9800;box-shadow:0 1px 0 0 #ff9800;outline:0 none}.rfipdropdown--orange .rfipicons__cp{border:0 none;border-bottom:1px solid #ffa726;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--orange .rfipicons__cp:active,.rfipdropdown--orange .rfipicons__cp:focus{border-bottom-color:#ff9800;-webkit-box-shadow:0 1px 0 0 #ff9800;box-shadow:0 1px 0 0 #ff9800;outline:0 none}.rfipdropdown--orange .rfipicons__left,.rfipdropdown--orange .rfipicons__right{background-color:#ffcc80;border:1px solid #ffcc80;color:#ef6c00}.rfipdropdown--orange .rfipicons__left:hover,.rfipdropdown--orange .rfipicons__right:hover{background-color:#ffa726;border:1px solid #ffa726}.rfipdropdown--orange .rfipicons__left:active,.rfipdropdown--orange .rfipicons__left:focus,.rfipdropdown--orange .rfipicons__right:active,.rfipdropdown--orange .rfipicons__right:focus{border:1px solid #ffa726}.rfipdropdown--orange .rfipicons__ibox{background-color:#ffe0b2;border:1px solid #ffe0b2;color:#ef6c00}.rfipdropdown--orange .rfipicons__ibox:hover{background-color:#ffa726;border:1px solid #ffa726}.rfipdropdown--orange .rfipicons__ibox:active,.rfipdropdown--orange .rfipicons__ibox:focus{border:1px solid #ffa726}.rfipdropdown--orange .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--orange .rfipicons__icon--selected .rfipicons__ibox{background-color:#ffcc80}.rfipdropdown--orange .rfipsearch input{border:0 none;border-bottom:1px solid #ffa726;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--orange .rfipsearch input:active,.rfipdropdown--orange .rfipsearch input:focus{border-bottom-color:#ff9800;-webkit-box-shadow:0 1px 0 0 #ff9800;box-shadow:0 1px 0 0 #ff9800;outline:0 none}.rfipbtn--purple{background-color:#fff;border:1px solid #ba68c8}.rfipbtn--purple:active,.rfipbtn--purple:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #ab47bc}.rfipbtn--purple .rfipbtn__button{border:0 none transparent;border-left:1px solid #ba68c8;background-color:#e1bee7;color:#6a1b9a}.rfipbtn--purple .rfipbtn__button:hover{background-color:#ab47bc}.rfipbtn--purple .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #ba68c8;box-shadow:inset 0 0 10px 0 #ba68c8}.rfipbtn--purple .rfipbtn__icon{border:1px solid #ce93d8;color:#6a1b9a}.rfipbtn--purple .rfipbtn__icon--empty{color:#ba68c8}.rfipbtn--purple .rfipbtn__del{background-color:#ce93d8}.rfipbtn--purple .rfipbtn__del:hover{background-color:#ba68c8}.rfipbtn--purple .rfipbtn__del:active,.rfipbtn--purple .rfipbtn__del:focus{outline:1px solid #ba68c8}.rfipdropdown--purple{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #ba68c8}.rfipdropdown--purple input,.rfipdropdown--purple select{color:#424242}.rfipdropdown--purple .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #ab47bc;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--purple .rfipcategory select:active,.rfipdropdown--purple .rfipcategory select:focus{border-bottom-color:#9c27b0;-webkit-box-shadow:0 1px 0 0 #9c27b0;box-shadow:0 1px 0 0 #9c27b0;outline:0 none}.rfipdropdown--purple .rfipicons__cp{border:0 none;border-bottom:1px solid #ab47bc;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--purple .rfipicons__cp:active,.rfipdropdown--purple .rfipicons__cp:focus{border-bottom-color:#9c27b0;-webkit-box-shadow:0 1px 0 0 #9c27b0;box-shadow:0 1px 0 0 #9c27b0;outline:0 none}.rfipdropdown--purple .rfipicons__left,.rfipdropdown--purple .rfipicons__right{background-color:#ce93d8;border:1px solid #ce93d8;color:#6a1b9a}.rfipdropdown--purple .rfipicons__left:hover,.rfipdropdown--purple .rfipicons__right:hover{background-color:#ab47bc;border:1px solid #ab47bc}.rfipdropdown--purple .rfipicons__left:active,.rfipdropdown--purple .rfipicons__left:focus,.rfipdropdown--purple .rfipicons__right:active,.rfipdropdown--purple .rfipicons__right:focus{border:1px solid #ab47bc}.rfipdropdown--purple .rfipicons__ibox{background-color:#e1bee7;border:1px solid #e1bee7;color:#6a1b9a}.rfipdropdown--purple .rfipicons__ibox:hover{background-color:#ab47bc;border:1px solid #ab47bc}.rfipdropdown--purple .rfipicons__ibox:active,.rfipdropdown--purple .rfipicons__ibox:focus{border:1px solid #ab47bc}.rfipdropdown--purple .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--purple .rfipicons__icon--selected .rfipicons__ibox{background-color:#ce93d8}.rfipdropdown--purple .rfipsearch input{border:0 none;border-bottom:1px solid #ab47bc;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--purple .rfipsearch input:active,.rfipdropdown--purple .rfipsearch input:focus{border-bottom-color:#9c27b0;-webkit-box-shadow:0 1px 0 0 #9c27b0;box-shadow:0 1px 0 0 #9c27b0;outline:0 none}.rfipbtn--red{background-color:#fff;border:1px solid #e57373}.rfipbtn--red:active,.rfipbtn--red:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #ef5350}.rfipbtn--red .rfipbtn__button{border:0 none transparent;border-left:1px solid #e57373;background-color:#ffcdd2;color:#c62828}.rfipbtn--red .rfipbtn__button:hover{background-color:#ef5350}.rfipbtn--red .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #e57373;box-shadow:inset 0 0 10px 0 #e57373}.rfipbtn--red .rfipbtn__icon{border:1px solid #ef9a9a;color:#c62828}.rfipbtn--red .rfipbtn__icon--empty{color:#e57373}.rfipbtn--red .rfipbtn__del{background-color:#ef9a9a}.rfipbtn--red .rfipbtn__del:hover{background-color:#e57373}.rfipbtn--red .rfipbtn__del:active,.rfipbtn--red .rfipbtn__del:focus{outline:1px solid #e57373}.rfipdropdown--red{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #e57373}.rfipdropdown--red input,.rfipdropdown--red select{color:#424242}.rfipdropdown--red .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #ef5350;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--red .rfipcategory select:active,.rfipdropdown--red .rfipcategory select:focus{border-bottom-color:#f44336;-webkit-box-shadow:0 1px 0 0 #f44336;box-shadow:0 1px 0 0 #f44336;outline:0 none}.rfipdropdown--red .rfipicons__cp{border:0 none;border-bottom:1px solid #ef5350;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--red .rfipicons__cp:active,.rfipdropdown--red .rfipicons__cp:focus{border-bottom-color:#f44336;-webkit-box-shadow:0 1px 0 0 #f44336;box-shadow:0 1px 0 0 #f44336;outline:0 none}.rfipdropdown--red .rfipicons__left,.rfipdropdown--red .rfipicons__right{background-color:#ef9a9a;border:1px solid #ef9a9a;color:#c62828}.rfipdropdown--red .rfipicons__left:hover,.rfipdropdown--red .rfipicons__right:hover{background-color:#ef5350;border:1px solid #ef5350}.rfipdropdown--red .rfipicons__left:active,.rfipdropdown--red .rfipicons__left:focus,.rfipdropdown--red .rfipicons__right:active,.rfipdropdown--red .rfipicons__right:focus{border:1px solid #ef5350}.rfipdropdown--red .rfipicons__ibox{background-color:#ffcdd2;border:1px solid #ffcdd2;color:#c62828}.rfipdropdown--red .rfipicons__ibox:hover{background-color:#ef5350;border:1px solid #ef5350}.rfipdropdown--red .rfipicons__ibox:active,.rfipdropdown--red .rfipicons__ibox:focus{border:1px solid #ef5350}.rfipdropdown--red .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--red .rfipicons__icon--selected .rfipicons__ibox{background-color:#ef9a9a}.rfipdropdown--red .rfipsearch input{border:0 none;border-bottom:1px solid #ef5350;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--red .rfipsearch input:active,.rfipdropdown--red .rfipsearch input:focus{border-bottom-color:#f44336;-webkit-box-shadow:0 1px 0 0 #f44336;box-shadow:0 1px 0 0 #f44336;outline:0 none}.rfipbtn--teal{background-color:#fff;border:1px solid #4db6ac}.rfipbtn--teal:active,.rfipbtn--teal:focus{-webkit-box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);box-shadow:0 1.5px 4px rgba(0,0,0,0.24),0 1.5px 6px rgba(0,0,0,0.12);border:1px solid #26a69a}.rfipbtn--teal .rfipbtn__button{border:0 none transparent;border-left:1px solid #4db6ac;background-color:#b2dfdb;color:#00695c}.rfipbtn--teal .rfipbtn__button:hover{background-color:#26a69a}.rfipbtn--teal .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #4db6ac;box-shadow:inset 0 0 10px 0 #4db6ac}.rfipbtn--teal .rfipbtn__icon{border:1px solid #80cbc4;color:#00695c}.rfipbtn--teal .rfipbtn__icon--empty{color:#4db6ac}.rfipbtn--teal .rfipbtn__del{background-color:#80cbc4}.rfipbtn--teal .rfipbtn__del:hover{background-color:#4db6ac}.rfipbtn--teal .rfipbtn__del:active,.rfipbtn--teal .rfipbtn__del:focus{outline:1px solid #4db6ac}.rfipdropdown--teal{-webkit-box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);box-shadow:0 15px 24px rgba(0,0,0,0.22),0 19px 76px rgba(0,0,0,0.3);color:#424242;background-color:#fff;border:1px solid #4db6ac}.rfipdropdown--teal input,.rfipdropdown--teal select{color:#424242}.rfipdropdown--teal .rfipcategory select{background-color:#fff;border:0 none;border-bottom:1px solid #26a69a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--teal .rfipcategory select:active,.rfipdropdown--teal .rfipcategory select:focus{border-bottom-color:#009688;-webkit-box-shadow:0 1px 0 0 #009688;box-shadow:0 1px 0 0 #009688;outline:0 none}.rfipdropdown--teal .rfipicons__cp{border:0 none;border-bottom:1px solid #26a69a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--teal .rfipicons__cp:active,.rfipdropdown--teal .rfipicons__cp:focus{border-bottom-color:#009688;-webkit-box-shadow:0 1px 0 0 #009688;box-shadow:0 1px 0 0 #009688;outline:0 none}.rfipdropdown--teal .rfipicons__left,.rfipdropdown--teal .rfipicons__right{background-color:#80cbc4;border:1px solid #80cbc4;color:#00695c}.rfipdropdown--teal .rfipicons__left:hover,.rfipdropdown--teal .rfipicons__right:hover{background-color:#26a69a;border:1px solid #26a69a}.rfipdropdown--teal .rfipicons__left:active,.rfipdropdown--teal .rfipicons__left:focus,.rfipdropdown--teal .rfipicons__right:active,.rfipdropdown--teal .rfipicons__right:focus{border:1px solid #26a69a}.rfipdropdown--teal .rfipicons__ibox{background-color:#b2dfdb;border:1px solid #b2dfdb;color:#00695c}.rfipdropdown--teal .rfipicons__ibox:hover{background-color:#26a69a;border:1px solid #26a69a}.rfipdropdown--teal .rfipicons__ibox:active,.rfipdropdown--teal .rfipicons__ibox:focus{border:1px solid #26a69a}.rfipdropdown--teal .rfipicons__ibox--error{color:#ef9a9a}.rfipdropdown--teal .rfipicons__icon--selected .rfipicons__ibox{background-color:#80cbc4}.rfipdropdown--teal .rfipsearch input{border:0 none;border-bottom:1px solid #26a69a;-webkit-transition:border .25s,-webkit-box-shadow .25s;transition:border .25s,-webkit-box-shadow .25s;-o-transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s;transition:box-shadow .25s,border .25s,-webkit-box-shadow .25s}.rfipdropdown--teal .rfipsearch input:active,.rfipdropdown--teal .rfipsearch input:focus{border-bottom-color:#009688;-webkit-box-shadow:0 1px 0 0 #009688;box-shadow:0 1px 0 0 #009688;outline:0 none}.rfipbtn--default .rfipbtn__icon{border:0;height:40px}.rfipbtn--default .rfipbtn__del{height:18px}.rfipicons__icon svg[fill="none"]{fill:none !important}.rfipbtn__elm svg[fill="none"]{fill:none !important}[class^=fipicon-]{font-style:normal;font-weight:400;font-variant:normal;text-transform:none;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}i.fipicon-angle-down:before{content:"\f140";font-family:dashicons}i.fipicon-angle-up:before{content:"\f142";font-family:dashicons}i.fipicon-angle-right:before{content:"\f345";font-family:dashicons}i.fipicon-angle-left:before{content:"\f341";font-family:dashicons}.kt-svg-icon-wrap{display:inline-block}.kt-svg-style-stacked .kt-svg-icon{border:0px solid #444444}
-.edit-post-sidebar .typography-family-select-form-row input[type=text],.kt-block-defaults-modal .typography-family-select-form-row input[type=text],.components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row input[type=text]{-webkit-box-shadow:none;box-shadow:none}.edit-post-sidebar .typography-family-select-form-row,.kt-block-defaults-modal .typography-family-select-form-row{margin-bottom:10px;z-index:200;position:relative}.components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row{z-index:200;position:relative;border-left:none;-webkit-box-shadow:none;box-shadow:none;display:block;overflow:inherit;-webkit-transition:none;-o-transition:none;transition:none;width:100%}.kt-font-family-icon svg path{fill:#555d66}.components-popover.kt-popover-font-family .components-popover__content{min-height:240px;overflow:visible;max-height:240px}.components-popover.kt-popover-font-family .components-popover__content{padding:10px;z-index:1}.components-popover.kt-popover-font-family .components-popover__content .kt-heading-fontfamily-title{margin:0;line-height:10px;text-transform:uppercase;padding-right:0;font-size:10px;margin-bottom:4px}.components-popover.kt-popover-font-family .components-popover__content .components-base-control .components-base-control__label,.components-popover.kt-popover-font-family .components-popover__content .components-base-control .components-toggle-control__label{margin-bottom:4px;font-size:10px;line-height:10px;text-transform:uppercase}.components-popover.kt-popover-font-family .components-popover__content .components-base-control .components-base-control__field{margin-bottom:0}.components-popover.kt-popover-font-family .components-popover__content .components-toggle-control .components-base-control__field .components-form-toggle{display:block;width:36px;margin:6px auto 0 auto}.components-popover.kt-popover-font-family .components-popover__content .components-toggle-control .components-base-control__field{margin:0;-ms-flex-direction:column-reverse;flex-direction:column-reverse}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings{margin-top:10px;display:-ms-flexbox;display:flex}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .components-base-control{-ms-flex:0 1 33.33%;flex:0 1 33.33%;margin-right:5px;margin-bottom:0}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .components-base-control:last-child{margin-right:0px}.components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row .kt-typography__control{min-height:28px;border:1px solid #8d96a0;border-radius:4px;-webkit-box-shadow:0 0 0 transparent;box-shadow:0 0 0 transparent}.components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row .kt-typography__control--is-focused{border-color:#2684ff}.components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row .kt-typography__indicator{padding:0 8px}.components-popover.kt-popover-font-family .components-popover__content p.kt-inline-size-title{font-size:10px;margin:0;line-height:15px;text-transform:uppercase}.components-popover.kt-popover-font-family .components-popover__content .kt-typography-number-input{width:70px;margin-right:0;-ms-flex:none;flex:none;display:inline-block}.components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options .components-button.kt-size-btn{background:transparent;border:0;border-bottom:0;padding:2px 4px;margin-bottom:0;outline:0;-webkit-box-shadow:none;box-shadow:none;line-height:20px;height:20px;width:auto;font-size:10px}.components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options .components-button.kt-size-btn.is-primary{color:#0085ba;background:#f2f2f2;-webkit-box-shadow:none;box-shadow:none}.components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options .components-button.kt-size-btn svg{width:12px;height:12px}.components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options{-ms-flex-positive:2;flex-grow:2}.components-popover.kt-popover-font-family .components-popover__content .kt-size-tite-device-wrap{display:-ms-flexbox;display:flex;text-align:right;-ms-flex-align:center;align-items:center}.components-popover.kt-popover-font-family .components-popover__content .kt-type-size-input-wrap .kt-typography-number-input{width:55%;-ms-flex:none;flex:none;margin-right:0;display:inline-block}.components-popover.kt-popover-font-family .components-popover__content .kt-type-size-input-wrap .kt-typography-size-type{width:40%;-ms-flex:none;flex:none;margin-right:0;display:inline-block}.components-popover.kt-popover-font-family .components-popover__content .kt-type-size-input-wrap{display:-ms-flexbox;display:flex;-ms-flex-pack:justify;justify-content:space-between}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-type-input-wrap{-ms-flex:0 1 33.33%;flex:0 1 33.33%;margin-right:5px;margin-bottom:0}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-size-input-wrap{-ms-flex:0 1 50%;flex:0 1 50%;margin-right:15px;margin-bottom:0}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-size-input-wrap:last-child{margin-right:0px}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-type-input-wrap .components-base-control{-ms-flex:none;flex:none;display:inline-block;margin-right:0;width:70%}.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-type-input-wrap .kt-unit{width:30%;display:inline-block;text-align:center}.edit-post-sidebar h2.kt-heading-size-title,.kt-block-defaults-modal h2.kt-heading-size-title{font-size:14px;margin-bottom:0;color:#555d66;margin-top:30px}.components-button-group.kt-size-type-options{margin:0;text-align:right;display:block;margin-bottom:-18px}.kt-size-type-options button.components-button.kt-size-btn{background:transparent;color:#777;border:0;-webkit-box-shadow:none;box-shadow:none;text-shadow:none;height:18px;line-height:18px;padding:0 4px;position:relative}.kt-size-type-options button.components-button.kt-size-btn.is-primary,.kt-size-type-options button.components-button.kt-size-btn.is-primary:focus:not(:disabled):not([aria-disabled=true]){color:#000;text-decoration:underline;background:transparent;-webkit-box-shadow:none;box-shadow:none;border:none;outline:none}.kt-size-type-options button.components-button.kt-size-btn:hover,.kt-size-type-options button.components-button.kt-size-btn:hover:focus:not(:disabled):not([aria-disabled=true]){color:#000;background:transparent;-webkit-box-shadow:none;box-shadow:none;border:none;outline:none}.kt-size-tabs .components-tab-panel__tabs{border-bottom:0;text-align:right;margin-top:-20px;margin-bottom:0}.kt-size-tabs .components-tab-panel__tabs button{background:transparent;border:0;border-bottom:0;padding:2px 4px;margin-bottom:0;outline:0;width:auto;font-size:10px}.kt-size-tabs .components-tab-panel__tabs button.active-tab{color:#0085ba;background:#f2f2f2}.kt-size-tabs .components-tab-panel__tabs button svg{width:15px;height:15px}h2.kt-heading-fontfamily-title{margin:30px 0 10px;font-size:14px;color:#555d66}button.components-button.components-icon-button.kt-font-clear-btn{display:block;margin-right:0;margin-left:auto;margin-top:-45px;text-align:center;padding:6px;text-indent:0}.select-search-box{width:auto;position:relative;margin-bottom:20px;background:#fff;border-radius:4px}.select-search-box::after{font-family:dashicons;content:"\f140";position:absolute;top:0;right:0;width:30px;text-align:center;line-height:30px;color:#222f3e;z-index:1}.select-search-box .select-search-box--input::after{display:none !important}.select-search-box .select-search-box__out{display:none}.select-search-box .select-search-box__search{display:block;width:100%;height:30px;border:none;background:none;outline:none;font-size:16px;padding:0 20px;color:#222f3e;-webkit-appearance:none;-webkit-box-sizing:border-box;box-sizing:border-box;position:relative;z-index:2;cursor:pointer;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;line-height:30px;-webkit-box-shadow:0 7px 14px 0 rgba(50,50,93,0.1),0 3px 6px 0 rgba(0,0,0,0.07);box-shadow:0 7px 14px 0 rgba(50,50,93,0.1),0 3px 6px 0 rgba(0,0,0,0.07)}.select-search-box input.select-search-box__search{line-height:1}.select-search-box .select-search-box--multiple .select-search-box__search{-webkit-box-shadow:none;box-shadow:none}.select-search-box .select-search-box--input .select-search-box__search{cursor:text}.select-search-box .select-search-box__search:focus{cursor:text}.select-search-box .select-search-box__search--placeholder{font-style:italic;font-weight:normal}.select-search-box .select-search-box input::-webkit-input-placeholder{color:#ccc;font-style:italic;font-weight:normal}.select-search-box .select-search-box input::-moz-placeholder{color:#ccc;font-style:italic;font-weight:normal}.select-search-box .select-search-box input:-moz-placeholder{color:#ccc;font-style:italic;font-weight:normal}.select-search-box .select-search-box input:-ms-input-placeholder{color:#ccc;font-style:italic;font-weight:normal}.select-search-box input[type='search']::-webkit-search-cancel-button,.select-search-box input[type='search']::-webkit-search-decoration{-webkit-appearance:none}.select-search-box .select-search-box__select{display:none;position:absolute;top:35px;height:220px;left:0;right:0;background:#fff;border-radius:4px;overflow:auto;-webkit-box-shadow:0 7px 14px 0 rgba(50,50,93,0.1),0 3px 6px 0 rgba(0,0,0,0.07);box-shadow:0 7px 14px 0 rgba(50,50,93,0.1),0 3px 6px 0 rgba(0,0,0,0.07);z-index:100;min-height:30px}.select-search-box .select-search-box--multiple .select-search-box__select{display:block;position:static;border-top:1px solid #eee;border-radius:0;-webkit-box-shadow:none;box-shadow:none}.select-search-box .select-search-box__select--display{display:block}.select-search-box .select-search-box__option{font-size:13px;font-weight:400;color:#616b74;line-height:30px;margin-bottom:0;padding:0px 10px;border-top:1px solid #eee;cursor:pointer;white-space:nowrap;overflow:hidden;-o-text-overflow:ellipsis;text-overflow:ellipsis;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.select-search-box .select-search-box__option:first-child{border-top:none}.select-search-box .select-search-box__option--hover,.select-search-box .select-search-box__option:hover{background:#f4f7fa}.select-search-box .select-search-box__option--selected{background:#54A0FF;color:#fff;border-top-color:#2184ff}.select-search-box .select-search-box__option--selected:hover,.select-search-box .select-search-box__option--selected.select-search-box__option--hover{background:#2184ff;color:#fff;border-top-color:#2184ff}.select-search-box .select-search-box__group{margin-top:20px;padding-top:20px;border-top:1px solid #eee;position:relative}.select-search-box .select-search-box__group-header{position:absolute;top:0;left:50%;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);background:white;padding:0 10px;color:rgba(0,0,0,0.5);font-size:12px}.wp-block-kadence-advancedheading mark{color:#f76a0c;background:transparent}
-.kb-device-choice.kt-size-tabs>.components-tab-panel__tabs{margin-top:0}.kb-add-new-tab-contain{text-align:right}.kt-title-text.is-selected{min-width:5px}.wp-block[data-type="kadence/tab"]>.block-editor-block-list__block-edit>.editor-block-mover{display:none !important}.kt-tabs-layout-vtabs .kadence-blocks-tab-item__control-menu{left:auto;right:0;-webkit-transform:translateX(0);-ms-transform:translateX(0);transform:translateX(0)}.kadence-blocks-tab-item__control-menu .components-icon-button{color:white;padding:0}.components-button.kt-tab-add.is-button.is-primary{border:0;text-shadow:none;-webkit-box-shadow:none;box-shadow:none;vertical-align:top;padding-bottom:2px}.components-button.kt-tab-add.is-button.is-primary svg{margin-top:4px}.kadence-blocks-tab-item__control-menu{position:absolute;top:-24px;background:#0085ba;padding:2px;left:50%;-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%);display:none}.block-editor-block-list__layout .kt-tabs-title-list.kb-tabs-list-columns:not(.kb-tab-title-columns-1):not(.kb-tab-title-columns-2):not(.kb-tab-title-columns-3):not(.kb-tab-title-columns-4){padding-top:40px}.kt-tabs-title-list.kb-tabs-list-columns:not(.kb-tab-title-columns-5):not(.kb-tab-title-columns-6):not(.kb-tab-title-columns-7):not(.kb-tab-title-columns-8):not(.kb-tab-title-columns-9):not(.kb-tab-title-columns-10) li:last-child .kadence-blocks-tab-item__control-menu{left:0;-webkit-transform:translateX(0);-ms-transform:translateX(0);transform:translateX(0)}.kt-tabs-title-list li{position:relative}li.kt-tab-title-active .kadence-blocks-tab-item__control-menu{display:-ms-flexbox;display:flex}.kt-select-starter-style-tabs{padding:20px;border:2px dashed #ddd;text-align:center;position:relative;z-index:10}.kt-select-starter-style-tabs-title{text-transform:uppercase;padding-bottom:10px;font-size:16px}.kt-select-starter-style-tabs .kt-inital-tabs-style-btn{height:auto;width:320px;background:white;-webkit-box-shadow:none;box-shadow:none;border:2px solid transparent;padding:2px;margin-right:15px;margin-bottom:5px}.kt-select-starter-style-tabs .kt-inital-tabs-style-btn svg{width:100%}.kt-select-starter-style-tabs .kt-init-tabs-btn-group .kt-inital-tabs-style-btn:first-child{width:100%;text-align:center;-ms-flex-pack:center;justify-content:center;border:0;padding:2px;margin-right:0;margin-bottom:5px}.kt-select-starter-style-tabs .kt-init-tabs-btn-group .kt-inital-tabs-style-btn:first-child:hover{text-decoration:underline}.components-button-group button.components-button.kt-init-open-tab{width:auto;padding:4px 10px;border-radius:3px !important;height:auto;text-shadow:none;-webkit-box-shadow:none;box-shadow:none;margin-bottom:5px}.kt-select-starter-style-tabs .kt-init-tabs-btn-group .kt-inital-tabs-style-btn:first-child:focus{background:transparent;-webkit-box-shadow:none;box-shadow:none}.kt-select-starter-style-tabs .kt-inital-tabs-style-btn:hover{border:2px solid #aaa;background:white;-webkit-box-shadow:none;box-shadow:none}.kt-inspect-tabs .components-button-group .kt-layout-btn.kt-tablayout{border-radius:0}.components-button-group .kt-layout-btn.kt-tablayout{height:46px}.components-button-group .kt-layout-btn.kt-tablayout svg{width:40px;height:40px}.components-button-group .kt-layout-btn.kt-tablayout:hover,.components-button-group .kt-layout-btn.kt-tablayout.is-primary,.components-button-group .kt-layout-btn.kt-tablayout:focus:not(:disabled):not([aria-disabled=true]){background:#eee;border-color:#222}.components-button-group .kt-layout-btn.kt-tablayout:hover svg path,.components-button-group .kt-layout-btn.kt-tablayout:hover svg rect,.components-button-group .kt-layout-btn.kt-tablayout.is-primary svg path,.components-button-group .kt-layout-btn.kt-tablayout.is-primary svg rect,.components-button-group .kt-layout-btn.kt-tablayout:focus:not(:disabled):not([aria-disabled=true]) svg path,.components-button-group .kt-layout-btn.kt-tablayout:focus:not(:disabled):not([aria-disabled=true]) svg rect{fill:#222}.kt-tab-title .editor-rich-text{display:-ms-inline-flexbox;display:inline-flex}.edit-post-sidebar p.kt-setting-label,.kt-block-defaults-modal p.kt-setting-label{font-weight:600;color:#191e23;padding:0 0 5px;clear:both;margin-top:0}.kt-size-type-options.kt-outline-control .components-button.kt-size-btn{padding:2px 4px}.kt-size-type-options.kt-outline-control .components-button.kt-size-btn svg{fill:#777;width:15px;height:15px}.kt-size-type-options.kt-outline-control .components-button.kt-size-btn.is-primary svg{fill:#222}.components-panel__body>.components-panel__body>.components-panel__body-title>.components-panel__body-toggle{padding:10px 10px 10px 30px}.components-range-control.kt-icon-rangecontrol .components-base-control__label{width:30px}.kt-inspect-tabs.kt-hover-tabs.kt-no-ho-ac-tabs .components-tab-panel__tabs button{width:33.33%;padding:6px 0;font-size:12px}.block-editor-block-list__layout .kt-tabs-title-list{padding:0;margin:0}.kt-tabs-title-list{margin:0;padding:0;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;list-style:none}.kt-tabs-title-list li{margin:0 4px -1px 0;cursor:pointer;list-style:none}.kt-tabs-title-list li .kt-tab-title{padding:8px 16px;display:-ms-flexbox;display:flex;color:#444;-ms-flex-align:center;align-items:center;border-style:solid;border-color:transparent;border-width:1px 1px 0 1px;border-top-left-radius:4px;border-top-right-radius:4px;-webkit-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out;-webkit-box-shadow:none !important;box-shadow:none !important;outline:0 !important}.kt-tabs-title-list li.kt-tab-title-active{z-index:4}.kt-tabs-title-list li.kt-tab-title-active .kt-tab-title{background-color:#fff;border-color:#dee2e6}.kt-tabs-title-list li.kt-tabs-has-icon-false .kt-tab-title{display:block}.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-direction:column;flex-direction:column}.kt-tab-alignment-center>.kt-tabs-wrap>.kt-tabs-title-list{-ms-flex-pack:center;justify-content:center}.kt-tab-alignment-right>.kt-tabs-wrap>.kt-tabs-title-list{-ms-flex-pack:end;justify-content:flex-end}.kt-tabs-content-wrap:before,.kt-tabs-content-wrap:after{content:'';clear:both;display:table}.kt-tabs-content-wrap{border:1px solid #dee2e6;padding:20px;text-align:left;position:relative}.wp-block-kadence-tabs .editor-block-list__layout .editor-block-list__block{max-width:none !important}.kt-tabs-content-wrap [data-type="kadence/tab"]{display:none}.wp-block-kadence-tabs.kt-active-tab-1>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="1"]{display:block}.wp-block-kadence-tabs.kt-active-tab-2>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="2"]{display:block}.wp-block-kadence-tabs.kt-active-tab-3>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="3"]{display:block}.wp-block-kadence-tabs.kt-active-tab-4>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="4"]{display:block}.wp-block-kadence-tabs.kt-active-tab-5>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="5"]{display:block}.wp-block-kadence-tabs.kt-active-tab-6>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="6"]{display:block}.wp-block-kadence-tabs.kt-active-tab-7>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="7"]{display:block}.wp-block-kadence-tabs.kt-active-tab-8>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="8"]{display:block}.wp-block-kadence-tabs.kt-active-tab-9>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="9"]{display:block}.wp-block-kadence-tabs.kt-active-tab-10>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="10"]{display:block}.wp-block-kadence-tabs.kt-active-tab-11>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="11"]{display:block}.wp-block-kadence-tabs.kt-active-tab-12>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="12"]{display:block}.wp-block-kadence-tabs.kt-active-tab-13>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="13"]{display:block}.wp-block-kadence-tabs.kt-active-tab-14>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="14"]{display:block}.wp-block-kadence-tabs.kt-active-tab-15>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="15"]{display:block}.wp-block-kadence-tabs.kt-active-tab-16>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="16"]{display:block}.wp-block-kadence-tabs.kt-active-tab-17>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="17"]{display:block}.wp-block-kadence-tabs.kt-active-tab-18>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="18"]{display:block}.wp-block-kadence-tabs.kt-active-tab-19>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="19"]{display:block}.wp-block-kadence-tabs.kt-active-tab-20>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="20"]{display:block}.wp-block-kadence-tabs.kt-active-tab-21>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="21"]{display:block}.wp-block-kadence-tabs.kt-active-tab-22>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="22"]{display:block}.wp-block-kadence-tabs.kt-active-tab-23>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="23"]{display:block}.wp-block-kadence-tabs.kt-active-tab-24>.kt-tabs-wrap>.kt-tabs-content-wrap>.editor-inner-blocks>.editor-block-list__layout>[data-tab="24"]{display:block}.kt-tabs-layout-vtabs:after,.kt-tabs-wrap:after{clear:both;display:table;content:''}.kt-tabs-layout-vtabs>.kt-tabs-wrap>.kt-tabs-title-list{float:left;width:30%;-ms-flex-direction:column;flex-direction:column}.kt-tabs-layout-vtabs>.kt-tabs-wrap>.kt-tabs-title-list li{margin:0 -1px 4px 0}.kt-tabs-layout-vtabs>.kt-tabs-wrap>.kt-tabs-title-list li .kt-tab-title{border-width:1px 0px 1px 1px;border-top-left-radius:0;border-top-right-radius:0}.kt-tabs-layout-vtabs>.kt-tabs-wrap>.kt-tabs-content-wrap{float:left;width:70%}.kt-tabs-layout-vtabs.kt-tab-alignment-left>.kt-tabs-wrap>.kt-tabs-title-list li .kt-tab-title{-ms-flex-align:center;align-items:center;-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-wrap>.kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-wrap>.kt-tabs-title-list li{text-align:center}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-wrap>.kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:center;justify-content:center}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-wrap>.kt-tabs-title-list li .kb-tab-titles-wrap{-ms-flex-align:center;align-items:center}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-wrap>.kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-wrap>.kt-tabs-title-list li{text-align:right}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-wrap>.kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:end;justify-content:flex-end;-ms-flex-align:center;align-items:center}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-wrap>.kt-tabs-title-list li .kb-tab-titles-wrap{-ms-flex-align:end;align-items:flex-end}.kt-tabs-svg-show-only .editor-rich-text{display:none}.kt-title-svg-side-left{padding-right:5px}.kt-title-svg-side-right{padding-left:5px}.kt-tabs-svg-show-only .kt-title-svg-side-right{padding-left:0px}.kt-tabs-svg-show-only .kt-title-svg-side-left{padding-right:0px}.kt-tabs-wrap{margin:0 auto}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-wrap>.kt-tabs-title-list li .kb-tab-titles-wrap{-ms-flex-align:center;align-items:center}.kb-tab-titles-wrap{display:-ms-inline-flexbox;display:inline-flex;-ms-flex-direction:column;flex-direction:column}.kt-title-sub-text{font-size:14px;line-height:24px}ul.kt-tabs-title-list.kb-tab-title-columns-8>li{-ms-flex:0 1 12.5%;flex:0 1 12.5%}ul.kt-tabs-title-list.kb-tab-title-columns-7>li{-ms-flex:0 1 14.28%;flex:0 1 14.28%}ul.kt-tabs-title-list.kb-tab-title-columns-6>li{-ms-flex:0 1 16.67%;flex:0 1 16.67%}ul.kt-tabs-title-list.kb-tab-title-columns-5>li{-ms-flex:0 1 20%;flex:0 1 20%}ul.kt-tabs-title-list.kb-tab-title-columns-4>li{-ms-flex:0 1 25%;flex:0 1 25%}ul.kt-tabs-title-list.kb-tab-title-columns-3>li{-ms-flex:0 1 33.33%;flex:0 1 33.33%}ul.kt-tabs-title-list.kb-tab-title-columns-2>li{-ms-flex:0 1 50%;flex:0 1 50%}ul.kt-tabs-title-list.kb-tab-title-columns-1>li{-ms-flex:0 1 100%;flex:0 1 100%}ul.kt-tabs-title-list.kb-tab-title-columns-1>li>.kt-tab-title{margin-right:0px !important}ul.kt-tabs-title-list.kb-tabs-list-columns>li:last-child>.kt-tab-title{margin-right:0px !important}ul.kt-tabs-title-list.kb-tabs-list-columns .kt-tab-title{-ms-flex-pack:center;justify-content:center;text-align:center}.kt-tab-alignment-center ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap{-ms-flex-align:center;align-items:center}.kt-tab-alignment-right ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap{-ms-flex-align:end;align-items:flex-end}
-.kb-upload-inline-btn.kt-cta-upload-btn{margin-bottom:0}.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media .editor-media-placeholder{padding:1em;margin:0}.edit-post-sidebar .kb-image-size-select-form-row input[type=text],.kt-block-defaults-modal .kb-image-size-select-form-row input[type=text]{-webkit-box-shadow:none;box-shadow:none}.kb-image-size-container .kb-image-size-select-form-row{margin-bottom:10px;z-index:200;position:relative}.kb-image-size-container .kb-image-size-title{font-weight:normal;margin-bottom:4px}.kb-image-edit-settings-container{display:-ms-flexbox;display:flex;margin-bottom:10px}.kadence-info-box-image-intrisic{height:0}.kt-infobox-textcontent .kt-blocks-info-box-text{margin-top:0}.kt-controls-link-wrap .editor-url-input input[type=text]{width:100%}.edit-post-sidebar .kt-controls-link-wrap h2{margin-top:0}.kt-select-starter-style-tabs.kt-select-starter-style-infobox .kt-inital-tabs-style-btn{width:120px}.kt-info-halign-center{text-align:center}.kt-info-halign-center .kadence-info-box-image-inner-intrisic-container{margin:0 auto}.kt-info-halign-right{text-align:right}.kt-info-halign-right .kadence-info-box-image-inner-intrisic-container{margin:0 0 0 auto}.kt-info-halign-left{text-align:left}.kt-info-halign-left .kadence-info-box-image-inner-intrisic-container{margin:0 auto 0 0}.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media{display:inline-block}.kt-blocks-info-box-media-align-top .kt-infobox-textcontent{display:block}.wp-block-kadence-infobox .kt-blocks-info-box-text{margin-bottom:0}.kt-blocks-info-box-media,.kt-blocks-info-box-link-wrap{border:0 solid transparent;-webkit-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);-o-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95)}.kt-blocks-info-box-title,.kt-blocks-info-box-text,.kt-blocks-info-box-learnmore{-webkit-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);-o-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95)}.kt-blocks-info-box-learnmore{border:0 solid transparent}.kt-blocks-info-box-text{color:#555555}.wp-block-kadence-infobox .kt-blocks-info-box-learnmore-wrap{display:inline-block;width:auto}.kt-blocks-info-box-media-align-left{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:start;justify-content:flex-start}.kt-blocks-info-box-media-align-right{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:start;justify-content:flex-start;-ms-flex-direction:row-reverse;flex-direction:row-reverse}.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-top,.kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-top{-ms-flex-align:start;align-items:flex-start}.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-bottom,.kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-bottom{-ms-flex-align:end;align-items:flex-end}.kadence-info-box-image-intrisic.kb-info-box-image-type-svg{height:auto;padding-bottom:0}.kt-info-animate-grayscale img,.kt-info-animate-grayscale-border-draw img{-webkit-filter:grayscale(100%);filter:grayscale(100%);-webkit-transition:0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);-o-transition:0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);transition:0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95)}.kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale img,.kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale-border-draw img{-webkit-filter:grayscale(0);filter:grayscale(0)}.kt-info-animate-flip,.kt-info-icon-animate-flip{-webkit-perspective:1000;perspective:1000}.kt-blocks-info-box-link-wrap:hover .kt-info-animate-flip .kadence-info-box-image-inner-intrisic,.kt-blocks-info-box-link-wrap:hover .kt-info-icon-animate-flip .kadence-info-box-icon-inner-container{-webkit-transform:rotateY(180deg);transform:rotateY(180deg)}.kt-info-animate-flip .kadence-info-box-image-inner-intrisic,.kt-info-icon-animate-flip .kadence-info-box-icon-inner-container{-webkit-transition:0.6s;-o-transition:0.6s;transition:0.6s;-webkit-transform-style:preserve-3d;transform-style:preserve-3d;position:relative}.kt-info-animate-flip .kt-info-box-image-flip,.kt-info-icon-animate-flip .kt-info-svg-icon-flip{-webkit-backface-visibility:hidden;backface-visibility:hidden;position:absolute;top:0;left:0}.kt-info-animate-flip .kt-info-box-image,.kt-info-icon-animate-flip .kt-info-svg-icon{-webkit-backface-visibility:hidden;backface-visibility:hidden}.kt-info-animate-flip .kt-info-box-image,.kt-info-icon-animate-flip .kt-info-svg-icon{z-index:2}.kt-info-animate-flip .kt-info-box-image-flip,.kt-info-icon-animate-flip .kt-info-svg-icon-flip{-webkit-transform:rotateY(180deg);transform:rotateY(180deg)}.kt-info-media-animate-drawborder,.kt-info-media-animate-grayscale-border-draw{position:relative;-webkit-box-sizing:border-box;box-sizing:border-box}.kt-info-media-animate-drawborder::before,.kt-info-media-animate-drawborder::after,.kt-info-media-animate-grayscale-border-draw::before,.kt-info-media-animate-grayscale-border-draw::after{-webkit-box-sizing:border-box;box-sizing:border-box;content:'';position:absolute;border:0px solid transparent;width:0;height:0}.kt-info-media-animate-drawborder::before,.kt-info-media-animate-drawborder::after,.kt-info-media-animate-grayscale-border-draw::before,.kt-info-media-animate-grayscale-border-draw::after{top:0;left:0}.kt-info-media-animate-drawborder:after,.kt-info-media-animate-grayscale-border-draw:after{-webkit-transform:rotate(-90deg);-ms-transform:rotate(-90deg);transform:rotate(-90deg)}.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:before,.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:before{width:100%;height:100%;-webkit-transition:border-top-color 0.15s linear,border-right-color 0.15s linear 0.1s,border-bottom-color 0.15s linear 0.2s;-o-transition:border-top-color 0.15s linear,border-right-color 0.15s linear 0.1s,border-bottom-color 0.15s linear 0.2s;transition:border-top-color 0.15s linear,border-right-color 0.15s linear 0.1s,border-bottom-color 0.15s linear 0.2s}.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:after,.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:after{width:100%;height:100%;-webkit-transform:rotate(180deg);-ms-transform:rotate(180deg);transform:rotate(180deg);-webkit-transition:border-bottom-width 0s linear 0.35s,-webkit-transform 0.4s linear 0s;transition:border-bottom-width 0s linear 0.35s,-webkit-transform 0.4s linear 0s;-o-transition:transform 0.4s linear 0s,border-bottom-width 0s linear 0.35s;transition:transform 0.4s linear 0s,border-bottom-width 0s linear 0.35s;transition:transform 0.4s linear 0s,border-bottom-width 0s linear 0.35s,-webkit-transform 0.4s linear 0s}
-.kt-border-color-array-control .components-color-palette{padding-left:50px}.kt-border-color-array-control .kt-border-color-icon{float:left;width:40px;height:40px;display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;background:#f9f9f9;margin-right:10px}.rfipbtn.rfipbtn--accordion{background-color:#fff;border:1px solid #e0e0e0;width:96%}.rfipbtn.rfipbtn--accordion:active,.rfipbtn.rfipbtn--accordion:focus{border:1px solid #bdbdbd}.rfipbtn.rfipbtn--accordion .rfipbtn__current{-ms-flex:100%;flex:100%;-ms-flex-pack:start;justify-content:flex-start;padding:0}.rfipbtn.rfipbtn--accordion .rfipbtn__current svg.top-icon{-webkit-transform:rotate(180deg) !important;-ms-transform:rotate(180deg) !important;transform:rotate(180deg) !important}.rfipbtn.rfipbtn--accordion .rfipbtn__current .rfipbtn__icon{width:100%}.rfipbtn.rfipbtn--accordion .rfipbtn__current .rfipbtn__icon .rfipbtn__elm{width:100%}.rfipbtn.rfipbtn--accordion .rfipbtn__current .rfipbtn__icon .rfipbtn__elm svg{width:auto}.rfipbtn.rfipbtn--accordion .rfipbtn__button{border:0 none transparent;border-left:1px solid #e0e0e0;background-color:#f5f5f5;color:#424242}.rfipbtn.rfipbtn--accordion .rfipbtn__button:hover{background-color:#bdbdbd}.rfipbtn.rfipbtn--accordion .rfipbtn__button:active{-webkit-box-shadow:inset 0 0 10px 0 #e0e0e0;box-shadow:inset 0 0 10px 0 #e0e0e0}.rfipbtn.rfipbtn--accordion .rfipbtn__icon{border:0;color:#424242}.rfipbtn.rfipbtn--accordion .rfipbtn__icon--empty{color:#555d66;text-transform:none;text-align:left}.rfipbtn.rfipbtn--accordion .rfipbtn__del{background-color:#eee}.rfipbtn.rfipbtn--accordion .rfipbtn__del:hover{background-color:#e0e0e0}.rfipbtn.rfipbtn--accordion .rfipbtn__del:focus,.rfipbtn.rfipbtn--accordion .rfipbtn__del:active{outline:1px solid #e0e0e0}.rfipdropdown.rfipdropdown--accordion{max-height:240px;overflow:scroll}.rfipdropdown.rfipdropdown--accordion{background-color:#fff;border:1px solid #e0e0e0}.rfipdropdown.rfipdropdown--accordion .rfipdropdown__selector{overflow:hidden;padding:8px}.rfipdropdown.rfipdropdown--accordion .rfipicons__pager{display:none}.rfipdropdown.rfipdropdown--accordion .rfipicons__cp{border-bottom:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--accordion .rfipicons__cp:focus{border-bottom-color:#9e9e9e}.rfipdropdown.rfipdropdown--accordion .rfipicons__left,.rfipdropdown.rfipdropdown--accordion .rfipicons__right{background-color:#eee;border:1px solid #eee;color:#424242}.rfipdropdown.rfipdropdown--accordion .rfipicons__left:hover,.rfipdropdown.rfipdropdown--accordion .rfipicons__right:hover{background-color:#bdbdbd;border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--accordion .rfipicons__left:focus,.rfipdropdown.rfipdropdown--accordion .rfipicons__left:active,.rfipdropdown.rfipdropdown--accordion .rfipicons__right:focus,.rfipdropdown.rfipdropdown--accordion .rfipicons__right:active{border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--accordion .rfipicons__ibox{background-color:#f5f5f5;border:1px solid #f5f5f5;color:#424242}.rfipdropdown.rfipdropdown--accordion .rfipicons__ibox:hover{background-color:#bdbdbd;border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--accordion .rfipicons__ibox:focus,.rfipdropdown.rfipdropdown--accordion .rfipicons__ibox:active{border:1px solid #bdbdbd}.rfipdropdown.rfipdropdown--accordion .rfipicons__ibox--error{color:red}.rfipdropdown.rfipdropdown--accordion .rfipicons__icon{width:100%;height:50px;margin:2px 0}.rfipdropdown.rfipdropdown--accordion .rfipicons__icon svg{fill:#000;width:100px;-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1)}.rfipdropdown.rfipdropdown--accordion .rfipicons__icon svg.top-icon{-webkit-transform:rotate(180deg) !important;-ms-transform:rotate(180deg) !important;transform:rotate(180deg) !important}.rfipdropdown.rfipdropdown--accordion .rfipicons__icon--selected .rfipicons__ibox{background-color:#eee}.kt-accordion-selecter{border:2px dashed #aaa;font-size:12px;text-align:center;cursor:pointer;text-transform:uppercase;font-weight:bold;color:#999}.kt-accordion-wrap .kt-accordion-header-wrap{margin:0;padding:0}.kt-blocks-accordion-header{-ms-flex-line-pack:justify;align-content:space-between;-ms-flex-align:center;align-items:center;background-color:#f2f2f2;border:0 solid transparent;border-radius:0px;color:#444444;display:-ms-flexbox;display:flex;padding:8px 12px;text-align:left;-webkit-transition:all ease-in-out .2s;-o-transition:all ease-in-out .2s;transition:all ease-in-out .2s;width:100%}.kt-accordion-panel-inner{padding:20px;border:1px solid #eee;border-top-width:0}.kt-accordion-add-selecter{display:-ms-flexbox;display:flex}button.components-button.kt-accordion-add.is-button.is-primary{border:0;text-shadow:none;-webkit-box-shadow:none;box-shadow:none}.kt-accordion-add-selecter button.components-button.kt-accordion-remove{border:0;text-shadow:none;-webkit-box-shadow:none;box-shadow:none;background:#e1e1e1;border-radius:3px;margin-left:5px;height:28px;line-height:26px;padding:0 10px 1px}.kt-accordion-add-selecter button.components-button.kt-accordion-remove:not(:disabled):not([aria-disabled=true]):not(.is-default):hover{background:#eee;-webkit-box-shadow:none;box-shadow:none}button.components-button.kt-accordion-add.is-button.is-primary svg{margin-top:4px}.components-button-group button.components-button.kt-init-open-pane{width:100%;padding:4px 10px;border-radius:3px !important;height:auto;text-shadow:none;-webkit-box-shadow:none;box-shadow:none;margin-bottom:5px}.components-button-group button.components-button.kt-init-open-pane:focus:enabled{-webkit-box-shadow:none;box-shadow:none}.kt-blocks-accordion-icon-trigger{display:block;height:24px;margin-left:auto;position:relative;-webkit-transition:all ease-in-out 0.2s;-o-transition:all ease-in-out 0.2s;transition:all ease-in-out 0.2s;width:24px;min-width:24px;-webkit-box-sizing:content-box;box-sizing:content-box}.kt-blocks-accordion-title-wrap{display:-ms-flexbox;display:flex}.kt-pane-header-alignment-center .kt-blocks-accordion-header{text-align:center}.kt-pane-header-alignment-center .kt-blocks-accordion-header .kt-blocks-accordion-title-wrap{-ms-flex-positive:2;flex-grow:2;-ms-flex-pack:center;justify-content:center}.kt-pane-header-alignment-right .kt-blocks-accordion-header{text-align:right}.kt-pane-header-alignment-right .kt-blocks-accordion-header .kt-blocks-accordion-title-wrap{-ms-flex-positive:2;flex-grow:2;-ms-flex-pack:end;justify-content:flex-end}.kt-pane-header-alignment-right .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger{margin-left:10px}.kt-acccordion-button-label-hide .editor-rich-text{display:none}.kt-accodion-icon-style-none .kt-blocks-accordion-icon-trigger{display:none}.kt-accodion-icon-side-left .kt-blocks-accordion-icon-trigger{-ms-flex-order:-1;order:-1;margin-left:0;margin-right:10px}.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before{content:"";height:4px;position:absolute;-webkit-transition:all ease-in-out 0.1333333333s;-o-transition:all ease-in-out 0.1333333333s;transition:all ease-in-out 0.1333333333s;width:20px;left:2px;top:10px}.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(90deg);-ms-transform:rotate(90deg);transform:rotate(90deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-start-active-pane-1.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-2.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-3.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-4.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-5.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-6.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-7.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-8.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-9.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-10.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-start-active-pane-1.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-2.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-3.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-4.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-5.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-6.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-7.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-8.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-9.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-10.kt-accodion-icon-style-basic>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger{border-radius:50%}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before{width:16px;left:4px;top:10px}.kt-start-active-pane-1.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-2.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-3.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-4.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-5.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-6.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-7.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-8.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-9.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-10.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-start-active-pane-1.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-2.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-3.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-4.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-5.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-6.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-7.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-8.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-9.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-10.kt-accodion-icon-style-basiccircle>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg)}.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg)}.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before{content:"";height:4px;position:absolute;-webkit-transition:all ease-in-out 0.1333333333s;-o-transition:all ease-in-out 0.1333333333s;transition:all ease-in-out 0.1333333333s;width:20px;left:2px;top:10px}.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(90deg);-ms-transform:rotate(90deg);transform:rotate(90deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-start-active-pane-1.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-2.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-3.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-4.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-5.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-6.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-7.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-8.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-9.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-10.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg)}.kt-start-active-pane-1.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-2.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-3.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-4.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-5.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-6.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-7.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-8.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-9.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-10.kt-accodion-icon-style-xclose>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg)}.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger{border-radius:50%}.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before{width:16px;left:4px;top:10px}.kt-start-active-pane-1.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-2.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-3.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-4.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-5.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-6.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-7.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-8.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-9.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-10.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg)}.kt-start-active-pane-1.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-2.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-3.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-4.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-5.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-6.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-7.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-8.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-9.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-10.kt-accodion-icon-style-xclosecircle>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg)}.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{content:"";height:2px;position:absolute;top:11px;-webkit-transition:all ease-in-out 0.1333333333s;-o-transition:all ease-in-out 0.1333333333s;transition:all ease-in-out 0.1333333333s;width:12px}.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{left:2px;-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg);right:2px;-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-start-active-pane-1.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-2.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-3.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-4.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-5.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-6.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-7.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-8.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-9.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-10.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg)}.kt-start-active-pane-1.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-2.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-3.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-4.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-5.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-6.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-7.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-8.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-9.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-10.kt-accodion-icon-style-arrow>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg)}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger{border-radius:50%}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{width:10px}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{left:4px}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after{right:4px}.kt-start-active-pane-1.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-2.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-3.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-4.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-5.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-6.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-7.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-8.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-9.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before,.kt-start-active-pane-10.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg)}.kt-start-active-pane-1.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-1>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-2.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-2>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-3.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-3>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-4.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-4>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-5.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-5>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-6.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-6>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-7.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-7>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-8.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-8>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-9.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-9>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after,.kt-start-active-pane-10.kt-accodion-icon-style-arrowcircle>div>div>div>div>div>.kt-accordion-pane-10>div>.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg)}
-.kadence-blocks-list-item__control-menu{display:-ms-flexbox;display:flex}.kt-btn-size-settings-container .components-button-group .components-button.is-button.is-primary svg{fill:white}.kt-svg-icon-list-item-wrap{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;text-align:left}.kt-svg-icon-list-single{margin-right:10px;padding:4px 0}.kt-svg-icon-list-item-wrap .editor-rich-text{-ms-flex-positive:2;flex-grow:2}.block-editor-block-list__block[data-align=center] .kt-svg-icon-list-item-wrap{-ms-flex-pack:center;justify-content:center}.block-editor-block-list__block[data-align=center] .kt-svg-icon-list-item-wrap .editor-rich-text{min-width:20px;-ms-flex-positive:0;flex-grow:0}.kt-svg-icon-list-style-stacked .kt-svg-icon-list-single{border:0px solid transparent}.kt-svg-icon-list-columns-2{grid-template-columns:50% auto;grid-template-rows:auto;display:grid}.kt-svg-icon-list-columns-3{grid-template-columns:33% 33% auto;grid-template-rows:auto;display:grid}.kt-list-icon-aligntop .kt-svg-icon-list-item-wrap{-ms-flex-align:start;align-items:flex-start}.kt-list-icon-alignbottom .kt-svg-icon-list-item-wrap{-ms-flex-align:end;align-items:flex-end}
-.kt-blocks-carousel{padding:0 0 25px 0}.kt-blocks-carousel .slick-slider{position:relative;display:block;-webkit-box-sizing:border-box;box-sizing:border-box;-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-ms-touch-action:pan-y;touch-action:pan-y;-webkit-tap-highlight-color:transparent}.kt-blocks-carousel .slick-list{position:relative;overflow:hidden;display:block;margin:0;padding:0}.kt-blocks-carousel .slick-list:focus{outline:none}.kt-blocks-carousel .slick-list.dragging{cursor:pointer;cursor:hand}.kt-blocks-carousel .slick-slider .slick-track,.kt-blocks-carousel .slick-slider .slick-list{-webkit-transform:translate3d(0, 0, 0);transform:translate3d(0, 0, 0)}.kt-blocks-carousel .slick-track{position:relative;left:0;top:0;display:block;margin-left:auto;margin-right:auto}.kt-blocks-carousel .slick-track:before,.kt-blocks-carousel .slick-track:after{content:"";display:table}.kt-blocks-carousel .slick-track:after{clear:both}.kt-blocks-carousel .slick-loading .slick-track{visibility:hidden}.kt-blocks-carousel .slick-slide{float:left;height:100%;min-height:1px;display:none}[dir="rtl"] .kt-blocks-carousel .slick-slide{float:right}.kt-blocks-carousel .slick-slide img{display:block}.kt-blocks-carousel .slick-slide.slick-loading img{display:none}.kt-blocks-carousel .slick-slide.dragging img{pointer-events:none}.kt-blocks-carousel .slick-initialized .slick-slide{display:block}.kt-blocks-carousel .slick-loading .slick-slide{visibility:hidden}.kt-blocks-carousel .slick-vertical .slick-slide{display:block;height:auto;border:1px solid transparent}.kt-blocks-carousel .slick-arrow.slick-hidden{display:none}.kt-blocks-carousel .slick-slider:hover .slick-prev,.kt-blocks-carousel .slick-slider:hover .slick-next{opacity:.75}.kt-blocks-carousel .slick-slider:hover .slick-prev:hover,.kt-blocks-carousel .slick-slider:hover .slick-prev:focus,.kt-blocks-carousel .slick-slider:hover .slick-next:hover,.kt-blocks-carousel .slick-slider:hover .slick-next:focus{outline:none;opacity:1}.kt-blocks-carousel .slick-slider:hover .slick-prev.slick-disabled,.kt-blocks-carousel .slick-slider:hover .slick-next.slick-disabled{opacity:.25}.kt-blocks-carousel .slick-prev,.kt-blocks-carousel .slick-next{position:absolute;display:block;height:50px;width:30px;line-height:0px;font-size:0px;cursor:pointer;background:rgba(0,0,0,0.8);color:white;top:50%;-webkit-transform:translate(0, -50%);-ms-transform:translate(0, -50%);transform:translate(0, -50%);padding:0;border:none;outline:none;opacity:.25;z-index:1}.kt-blocks-carousel .slick-prev:hover,.kt-blocks-carousel .slick-prev:focus,.kt-blocks-carousel .slick-next:hover,.kt-blocks-carousel .slick-next:focus{outline:none;opacity:1}.kt-blocks-carousel .slick-prev.slick-disabled,.kt-blocks-carousel .slick-next.slick-disabled{opacity:0}.kt-blocks-carousel [dir="rtl"] .slick-prev{left:auto;right:0px;-webkit-transform:translate(0, -50%) rotate(180deg);-ms-transform:translate(0, -50%) rotate(180deg);transform:translate(0, -50%) rotate(180deg)}.kt-blocks-carousel .slick-prev{left:0px}.kt-blocks-carousel [dir="rtl"] .slick-next{left:-25px;right:auto;-webkit-transform:translate(0, -50%) rotate(180deg);-ms-transform:translate(0, -50%) rotate(180deg);transform:translate(0, -50%) rotate(180deg)}.kt-blocks-carousel .slick-next{right:0px}.kt-blocks-carousel .kt-carousel-arrowstyle-blackonlight .slick-prev,.kt-blocks-carousel .kt-carousel-arrowstyle-blackonlight .slick-next{background:rgba(255,255,255,0.8);color:black}.kt-blocks-carousel .kt-carousel-arrowstyle-outlineblack .slick-prev,.kt-blocks-carousel .kt-carousel-arrowstyle-outlineblack .slick-next{background:transparent;border:2px solid #000000;color:black}.kt-blocks-carousel .kt-carousel-arrowstyle-outlinewhite .slick-prev,.kt-blocks-carousel .kt-carousel-arrowstyle-outlinewhite .slick-next{background:transparent;border:2px solid #ffffff;color:#ffffff}.kt-blocks-carousel .slick-dotted.slick-slider{margin-bottom:30px}.kt-blocks-carousel .slick-dots{position:absolute;bottom:-25px;list-style:none;display:block;text-align:center;padding:0 0 5px 0;margin:0;left:0;width:100%}.kt-blocks-carousel .slick-dots li{position:relative;display:inline-block;height:20px;width:20px;margin:0;padding:0;cursor:pointer}.kt-blocks-carousel .slick-dots li button{border:0;background:transparent;display:block;height:20px;width:20px;outline:none;line-height:0px;font-size:0px;color:transparent;padding:5px;cursor:pointer}.kt-blocks-carousel .slick-dots li button:hover,.kt-blocks-carousel .slick-dots li button:focus{outline:none}.kt-blocks-carousel .slick-dots li button:hover:before,.kt-blocks-carousel .slick-dots li button:focus:before{opacity:1}.kt-blocks-carousel .slick-dots li button:before{position:absolute;top:0;left:0;content:"•";width:20px;height:20px;font-size:30px;line-height:20px;text-align:center;color:#000;opacity:.25;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.kt-blocks-carousel .slick-dots li.slick-active button:before{color:#000;opacity:.75}.kt-blocks-carousel .kt-carousel-dotstyle-light .slick-dots li button:before{color:white}.kt-blocks-carousel .kt-carousel-dotstyle-light .slick-dots li.slick-active button:before{color:white}.kt-blocks-carousel .kt-carousel-dotstyle-outlinedark .slick-dots li button:before{content:"\25CB";font-size:21px;line-height:18px}.kt-blocks-carousel .kt-carousel-dotstyle-outlinedark .slick-dots li.slick-active button:before{content:"•";font-size:30px;line-height:20px}.kt-blocks-carousel .kt-carousel-dotstyle-outlinelight .slick-dots li button:before{content:"\25CB";color:white;font-size:21px;line-height:18px}.kt-blocks-carousel .kt-carousel-dotstyle-outlinelight .slick-dots li.slick-active button:before{color:white;content:"•";font-size:30px;line-height:20px}.wp-block-kadence-testimonials .kt-blocks-carousel{padding-bottom:35px}.wp-block-kadence-testimonials .kt-blocks-carousel.kt-carousel-container-dotstyle-none{padding-bottom:0}.wp-block-kadence-testimonials .kt-blocks-carousel .slick-slider:not(.kt-carousel-arrowstyle-none){padding-left:35px;padding-right:35px}.kt-spacer-sidebar-15{height:15px}.kt-testimonial-item__move-menu{display:none;position:absolute;right:0;top:0}.kt-testimonial-item-wrap:hover .kt-testimonial-item__move-menu{display:-ms-inline-flexbox;display:inline-flex}.kt-testimonial-item__move-menu .components-button{padding:4px;background:rgba(255,255,255,0.8)}.kt-testimonial-item__move-menu .components-button:focus:enabled{border-color:transparent;outline:0;outline-offset:0;-webkit-box-shadow:none;box-shadow:none;color:#555d66}.components-button-group.kt-style-btn-group button.components-button.kt-style-btn{width:50%;border:0;height:auto;border-radius:0;background:transparent;padding:8px;border:2px solid transparent;-webkit-box-shadow:none;box-shadow:none}.components-button-group button.components-button.kt-style-btn svg{width:100%}.kt-style-btn-group{margin-bottom:10px}.components-button-group .components-button.is-button.is-primary.kt-style-btn,.components-button-group .components-button.kt-style-btn.is-button:focus{border-color:#aaaaaa;background:transparent;outline:0;-webkit-box-shadow:none;box-shadow:none}.components-button-group button.components-button.kt-style-btn:hover{border-color:#eeeeee}.kt-testimonial-grid-wrap{display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr;grid-gap:30px 30px}.kt-testimonial-columns-1 .kt-testimonial-grid-wrap{display:block}.kt-testimonial-columns-3 .kt-testimonial-grid-wrap{grid-template-columns:1fr 1fr 1fr}.kt-testimonial-columns-4 .kt-testimonial-grid-wrap{grid-template-columns:1fr 1fr 1fr 1fr}.kt-testimonial-columns-5 .kt-testimonial-grid-wrap{grid-template-columns:1fr 1fr 1fr 1fr 1fr}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap{width:100%}.kt-testimonial-media-inner-wrap{overflow:hidden;border:0 solid transparent;width:60px;margin:0 15px 0 0;border-radius:100%}.kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic{padding-bottom:100%;height:0;position:relative}.kt-testimonial-media-inner-wrap .kt-testimonial-image{background-position:center;background-repeat:no-repeat;background-size:cover;width:100%;height:100%;position:absolute;left:0;padding:0;border-radius:100%}.kt-testimonial-media-inner-wrap .kt-testimonial-image-placeholder{background:#f2f2f2;width:100%;height:100%;border-radius:100%;-ms-flex-pack:center;justify-content:center;position:absolute}.kt-testimonial-media-inner-wrap .kt-svg-testimonial-icon{position:absolute;width:100%;height:100%}.kt-testimonial-item-wrap{border:0 solid transparent;max-width:500px;text-align:center;margin:0 auto;position:relative}.kt-testimonial-meta-wrap{display:-ms-flexbox;display:flex;-ms-flex-pack:center;justify-content:center;-ms-flex-align:center;align-items:center;margin-top:10px}.kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:left}.kt-svg-testimonial-global-icon{border:2px solid #eeeeee;border-radius:100%;background:transparent;color:#444444;padding:20px}.kt-svg-testimonial-global-icon-wrap{margin:0 0 10px 0}.kt-testimonial-style-card .kt-testimonial-media-inner-wrap{width:auto;margin:0 0 15px 0;border-radius:0}.kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic{padding-bottom:50%}.kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kt-testimonial-image,.kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kt-testimonial-image-placeholder{border-radius:0}.kt-testimonial-style-card .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:center}.kt-testimonial-style-card.kt-testimonials-icon-on.kt-testimonial-halign-center .kt-testimonial-item-wrap{text-align:left}.kt-testimonial-style-card .kt-svg-testimonial-global-icon-wrap{float:left;margin:0 10px 0 0}.kt-testimonial-style-card.kt-testimonial-halign-right .kt-svg-testimonial-global-icon-wrap{float:right}.kt-testimonial-style-card.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap{margin:0 0 15px 0}.kt-testimonial-style-bubble .kt-testimonial-text-wrap{border:2px solid #eee;padding:20px;position:relative;border-radius:10px}.kt-testimonial-style-bubble .kt-testimonial-text-wrap:after{height:0;left:50%;top:100%;position:absolute;border-top:14px solid #eee;border-bottom:14px solid transparent;border-left:14px solid transparent;border-right:14px solid transparent;content:'';-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%);width:0}.kt-testimonial-style-bubble .kt-testimonial-meta-wrap{margin-top:20px}.kt-testimonial-style-bubble.kt-testimonial-halign-left .kt-testimonial-meta-wrap{margin-left:6px}.kt-testimonial-style-bubble.kt-testimonial-halign-left.kt-testimonials-media-off .kt-testimonial-meta-wrap{margin-left:20px}.kt-testimonial-style-bubble.kt-testimonial-halign-right .kt-testimonial-meta-wrap{margin-right:6px}.kt-testimonial-style-bubble.kt-testimonial-halign-right.kt-testimonials-media-off .kt-testimonial-meta-wrap{margin-right:20px}.kt-testimonial-style-bubble .kt-svg-testimonial-global-icon{background:#fff}.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap{margin:-55px 0 10px 0}.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-testimonial-item-wrap{padding-top:55px}.kt-testimonial-halign-center.kt-testimonials-media-off .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:center}.kt-testimonial-style-inlineimage .kt-testimonial-media-wrap{float:left}.kt-testimonial-style-inlineimage .kt-testimonial-text-wrap{border:2px solid #eee;padding:20px;position:relative;border-radius:10px;text-align:left}.kt-testimonial-style-inlineimage .kt-testimonial-text-wrap:after{height:0;left:20px;top:100%;position:absolute;border-top:14px solid #eee;border-bottom:14px solid transparent;border-left:14px solid transparent;border-right:14px solid transparent;content:'';-webkit-transform:none;-ms-transform:none;transform:none;width:0}.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap{margin-top:2px;-ms-flex-pack:start;justify-content:flex-start;padding-left:60px}.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:left;display:-ms-flexbox;display:flex}.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap .kt-testimonial-name-wrap{padding-right:6px}.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-text-wrap{text-align:left}.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-media-wrap{float:right}.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-meta-wrap{padding-left:0px;padding-right:60px}.kt-testimonial-style-inlineimage .kt-svg-testimonial-global-icon{background:#fff}.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap{margin:-55px 0 10px 0}.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-testimonial-item-wrap{padding-top:55px}.kt-testimonial-halign-left .kt-testimonial-item-wrap{text-align:left;margin:0}.kt-testimonial-halign-left .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap{text-align:left}.kt-testimonial-halign-left .kt-testimonial-meta-wrap{-ms-flex-pack:start;justify-content:flex-start}.kt-testimonial-halign-left .kt-testimonial-text-wrap:after{left:20px;-webkit-transform:none;-ms-transform:none;transform:none}.kt-testimonial-halign-right .kt-testimonial-item-wrap{text-align:right;margin-left:auto;margin-right:0}.kt-testimonial-halign-right .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap{text-align:right}.kt-testimonial-halign-right .kt-testimonial-meta-wrap{-ms-flex-pack:start;justify-content:flex-start;-ms-flex-direction:row-reverse;flex-direction:row-reverse}.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap{margin:0 0 0 15px}.kt-testimonial-halign-right .kt-testimonial-text-wrap:after{left:auto;right:20px;-webkit-transform:none;-ms-transform:none;transform:none}.kt-testimonial-name a{color:inherit}.kt-testimonial-occupation a{color:inherit}
-.components-button-group.kt-style-btn-group.kb-gallery-type-select button.components-button.kt-style-btn{width:33%}.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-container>.components-form-file-upload{margin-top:10px}.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-container>.components-form-file-upload .editor-media-placeholder{margin:0}.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-container>.components-placeholder.wp-block-kadence-advancedgallery{margin-top:10px}.kb-image-size-container .kb-gallery-type-select-form-row{margin-bottom:10px;z-index:220;position:relative}.kb-gallery-custom-link{position:relative;z-index:2;padding:0 4px 4px;display:block}.kb-gallery-custom-link .block-editor-url-input{width:100%;border-top:4px solid #0085ba}.kb-gallery-custom-link .block-editor-url-input input[type=text]{width:100%;margin:0;line-height:18px;padding-right:40px}.kb-gallery-custom-link .block-editor-url-popover__settings-toggle{position:absolute;right:4px;top:4px}.wp-block-kadence-advancedgallery{overflow:hidden}.kb-gallery-main-contain li{list-style-type:none}.kadence-blocks-gallery-item figure:not(.is-selected):focus{outline:none}.kadence-blocks-gallery-item .is-selected{outline:0}.kadence-blocks-gallery-item .is-selected:before{content:'';position:absolute;border:4px solid #0085ba;left:0;right:0;top:0;bottom:0;z-index:1}.kadence-blocks-gallery-item .is-selected .kb-gallery-image-contain{outline:0}.kadence-blocks-gallery-item .is-transient img{opacity:0.3}.kadence-blocks-gallery-item .block-editor-rich-text{position:absolute;bottom:0;width:100%;max-height:100%;overflow-y:auto}.kadence-blocks-gallery-item figcaption{max-height:100%;overflow-y:auto}.kadence-blocks-gallery-item .block-editor-rich-text figcaption:not([data-is-placeholder-visible="true"]){position:relative;overflow:hidden}.kadence-blocks-gallery-item .is-selected .block-editor-rich-text{z-index:2}@supports ((position: -webkit-sticky) or (position: sticky)){.kadence-blocks-gallery-item .is-selected .block-editor-rich-text{right:0;left:0;margin-top:-4px}}.kadence-blocks-gallery-item .is-selected .block-editor-rich-text .block-editor-rich-text__inline-toolbar{top:0}.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__move-menu,.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__inline-menu{background-color:#0085ba}.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__move-menu .components-button,.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__inline-menu .components-button{color:#f4f4f4}.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__move-menu .components-button:focus,.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__inline-menu .components-button:focus{color:inherit}.kadence-blocks-gallery-item figcaption .block-editor-rich-text a{color:#f4f4f4}.kb-gallery-caption-style-below .kadence-blocks-gallery-item .block-editor-rich-text{position:relative;overflow:visible}.kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-slider .slick-slide.slick-current{z-index:10}.kb-gallery-caption-style-below .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .is-selected .block-editor-rich-text{margin-top:0}.kb-gallery-caption-style-below .kadence-blocks-gallery-item .is-selected .block-editor-rich-text .block-editor-rich-text__inline-toolbar{top:-40px}.kadence-blocks-library-gallery-item__move-menu,.kadence-blocks-library-gallery-item__inline-menu{padding:2px;display:-ms-inline-flexbox;display:inline-flex;z-index:20}.kadence-blocks-library-gallery-item__move-menu .components-button,.kadence-blocks-library-gallery-item__inline-menu .components-button{color:transparent}.kadence-blocks-library-gallery-item__inline-menu{position:absolute;top:0px;right:0px}.kadence-blocks-library-gallery-item__move-menu{position:absolute;top:0px;left:0px}.kadence-blocks-gallery-item__move-backward,.kadence-blocks-gallery-item__move-forward,.kadence-blocks-gallery-item__remove{padding:0}.kadence-blocks-gallery-item .components-spinner{position:absolute;top:50%;left:50%;margin-top:-9px;margin-left:-9px}.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain{margin:-5px}.kb-gallery-main-contain{display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;list-style-type:none;padding:0}.kb-gallery-main-contain .kadence-blocks-gallery-item{position:relative;padding:5px;margin:0}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner{position:relative;margin-bottom:0}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure{margin:0}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gal-image-radius{position:relative;overflow:hidden;margin:0 auto}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain{border:0;background:transparent;padding:0;margin:0;display:block;width:100%;-webkit-transition:all .3s ease-in-out;-o-transition:all .3s ease-in-out;transition:all .3s ease-in-out}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic{height:0;position:relative}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic img{position:absolute;-ms-flex:1;flex:1;height:100%;-o-object-fit:cover;object-fit:cover;width:100%;top:0;left:0}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-square{padding-bottom:100%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land43{padding-bottom:75%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land32{padding-bottom:66.67%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land21{padding-bottom:50%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land31{padding-bottom:33%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land41{padding-bottom:25%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port34{padding-bottom:133.33%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port23{padding-bottom:150%}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img{display:block;max-width:100%;height:auto}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img{width:100%}@supports ((position: -webkit-sticky) or (position: sticky)){.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img{width:auto}}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption{width:100%;max-height:100%;overflow:visible;padding:43px 10px 10px;font-size:13px;color:#f4f4f4;text-align:center;background:-webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(41,41,41,0.5)), to(rgba(41,41,41,0)));background:-webkit-linear-gradient(bottom, rgba(41,41,41,0.5) 0, rgba(41,41,41,0) 100%);background:-o-linear-gradient(bottom, rgba(41,41,41,0.5) 0, rgba(41,41,41,0) 100%);background:linear-gradient(0deg, rgba(41,41,41,0.5) 0, rgba(41,41,41,0) 100%)}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption img{display:inline}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption.editing-caption{padding-top:48px}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kadence-blocks-gallery-item-hide-caption figcaption{display:none}.kb-gallery-main-contain .kadence-blocks-gallery-item{width:100%}@media (min-width: 600px){.kb-gallery-main-contain[data-columns-xxl="2"] .kadence-blocks-gallery-item{width:50%}.kb-gallery-main-contain[data-columns-xxl="3"] .kadence-blocks-gallery-item{width:33.33333%}.kb-gallery-main-contain[data-columns-xxl="4"] .kadence-blocks-gallery-item{width:25%}.kb-gallery-main-contain[data-columns-xxl="5"] .kadence-blocks-gallery-item{width:20%}.kb-gallery-main-contain[data-columns-xxl="6"] .kadence-blocks-gallery-item{width:16.66667%}.kb-gallery-main-contain[data-columns-xxl="7"] .kadence-blocks-gallery-item{width:14.28571%}.kb-gallery-main-contain[data-columns-xxl="8"] .kadence-blocks-gallery-item{width:12.5%}}.kb-gallery-caption-style-below .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption.kadence-blocks-gallery-item__caption{padding:10px;margin-top:0;background:rgba(0,0,0,0.5)}.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item figcaption{opacity:0;-webkit-transition:opacity 0.3s ease-in-out;-o-transition:opacity 0.3s ease-in-out;transition:opacity 0.3s ease-in-out}.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item:hover figcaption,.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item .is-selected figcaption{opacity:1}.kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .block-editor-rich-text{top:0;margin:0}.kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;position:absolute;left:0;right:0;top:0;bottom:0;padding:10px;margin:0;opacity:0;-webkit-transition:opacity 0.3s ease-in-out;-o-transition:opacity 0.3s ease-in-out;transition:opacity 0.3s ease-in-out;background:rgba(0,0,0,0.5)}.kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item:hover figcaption,.kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .is-selected figcaption{opacity:1}.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain.kb-gallery-type-carousel,.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain.kb-gallery-type-fluidcarousel,.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain.kb-gallery-type-slider{margin:0}.kb-gallery-main-contain.kb-gallery-type-carousel,.kb-gallery-main-contain.kb-gallery-type-slider{display:block}.kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider,.kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-slider{margin:0 -5px;-webkit-user-select:auto;-moz-user-select:auto;-ms-user-select:auto;user-select:auto;-ms-touch-action:auto;touch-action:auto}.kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider .slick-slide,.kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-slider .slick-slide{padding:4px 5px}.kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-prev,.kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-prev{left:5px}.kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-next,.kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-next{right:5px}.kb-gallery-main-contain.kb-gallery-type-carousel .slick-slider .kadence-blocks-gallery-item,.kb-gallery-main-contain.kb-gallery-type-slider .slick-slider .kadence-blocks-gallery-item{padding:0 !important}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel{display:block}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-slider{margin:0;-webkit-user-select:auto;-moz-user-select:auto;-ms-user-select:auto;user-select:auto;-ms-touch-action:auto;touch-action:auto}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-slider .slick-slide{padding:4px 5px}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel.kb-carousel-mode-align-left .slick-slider .slick-slide{padding:4px 10px 4px 0}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-prev{left:0px}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-next{right:0px}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kadence-blocks-gallery-item{padding:0 !important}.kb-gallery-main-contain.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit{padding-bottom:100%}.kb-gallery-main-contain.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img{-o-object-fit:contain;object-fit:contain}.kb-gallery-type-carousel>.kt-blocks-carousel>.kadence-blocks-gallery-item{float:left}.kb-gallery-main-contain .kt-blocks-carousel:after{clear:both;display:table;content:''}.kb-gallery-main-contain.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit{padding-bottom:66.67%}.kb-gallery-main-contain.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img{-o-object-fit:contain;object-fit:contain}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-list figure{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-list figure .kb-gal-image-radius{height:300px;width:auto;margin:0 auto}.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-list figure .kb-gal-image-radius img{height:300px;width:auto;-ms-flex:1;flex:1;-o-object-fit:cover;object-fit:cover}.kb-gallery-type-carousel .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after,.kb-gallery-type-slider .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after{display:none}.kb-gallery-main-contain.kb-gallery-type-carousel .kb-has-image-ratio-inherit .kb-gal-image-radius,.kb-gallery-main-contain.kb-gallery-type-slider .kb-has-image-ratio-inherit .kb-gal-image-radius{border-radius:0}.kb-gallery-filter-vintage .kb-gallery-image-contain:after{content:'';position:absolute;left:0;right:0;top:0;bottom:0;-webkit-box-shadow:inset 0 0 100px rgba(0,0,20,0.4),inset 0 5px 15px rgba(0,0,0,0.1);box-shadow:inset 0 0 100px rgba(0,0,20,0.4),inset 0 5px 15px rgba(0,0,0,0.1);background:-webkit-linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),-webkit-linear-gradient(70deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%);background:-o-linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),-o-linear-gradient(70deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%);background:linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),linear-gradient(20deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%)}.kb-gallery-filter-vintage .kb-gallery-image-contain img{-webkit-filter:sepia(0.2) brightness(1.1) contrast(1.3);filter:sepia(0.2) brightness(1.1) contrast(1.3)}.kb-gallery-filter-grayscale .kb-gallery-image-contain img{-webkit-filter:grayscale(1);filter:grayscale(1)}.kb-gallery-filter-sepia .kb-gallery-image-contain img{-webkit-filter:sepia(0.5);filter:sepia(0.5)}.kb-gallery-filter-saturation .kb-gallery-image-contain img{-webkit-filter:saturate(1.6);filter:saturate(1.6)}.kb-gallery-filter-earlybird .kb-gallery-image-contain::after{background:-webkit-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);background:-o-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);background:radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);mix-blend-mode:overlay;content:'';position:absolute;left:0;right:0;top:0;bottom:0}.kb-gallery-filter-earlybird .kb-gallery-image-contain img{-webkit-filter:contrast(0.9) sepia(0.2);filter:contrast(0.9) sepia(0.2)}.kb-gallery-filter-toaster .kb-gallery-image-contain::after{background:-webkit-radial-gradient(circle, #804e0f, #3b003b);background:-o-radial-gradient(circle, #804e0f, #3b003b);background:radial-gradient(circle, #804e0f, #3b003b);mix-blend-mode:screen;content:'';position:absolute;left:0;right:0;top:0;bottom:0}.kb-gallery-filter-toaster .kb-gallery-image-contain img{-webkit-filter:contrast(1.5) brightness(0.9);filter:contrast(1.5) brightness(0.9)}.kb-gallery-filter-mayfair .kb-gallery-image-contain::after{background:-webkit-radial-gradient(40% 40%, circle, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);background:-o-radial-gradient(40% 40%, circle, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);background:radial-gradient(circle at 40% 40%, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);mix-blend-mode:overlay;opacity:.4;content:'';position:absolute;left:0;right:0;top:0;bottom:0}.kb-gallery-filter-mayfair .kb-gallery-image-contain img{-webkit-filter:contrast(1.1) saturate(1.1);filter:contrast(1.1) saturate(1.1)}
-.kt-block-default-palette .components-color-palette__item{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center}.kt-colors-add-new{margin-bottom:16px}.kb-colors-show-notice{background:#fef8ee;padding:10px;color:#222}.components-popover.kt-popover-color>.components-popover__content>.components-base-control{padding:0 10px}.kt-block-default-palette .components-color-palette__item-wrapper{-webkit-transform:scale(1.1);-ms-transform:scale(1.1);transform:scale(1.1)}.kt-block-default-palette .components-color-palette__item-wrapper:hover{-webkit-transform:scale(1.1);-ms-transform:scale(1.1);transform:scale(1.1)}.kt-block-default-palette .components-color-palette__item svg{color:#646464}.kt-colors-remove-last{display:inline-block;height:28px;width:28px;margin-right:14px;margin-bottom:14px}.kt-colors-remove-last .components-button{border-radius:50%;height:100%;width:100%;padding:0;display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center}.kt-blocks-width-control,.kt-blocks-control-wrap{padding:10px}.components-button-group .kt-editor-width-btn{background:transparent;-webkit-box-shadow:none;box-shadow:none;border:1px solid #eee;padding:8px;margin-right:0px;height:auto;width:100%;font-size:13px;margin-bottom:5px;text-shadow:none}.components-button-group .kt-editor-width-btn:hover,.components-button-group .kt-editor-width-btn.is-primary,.components-button-group .kt-editor-width-btn:focus:not(:disabled):not([aria-disabled=true]){border-color:#444;-webkit-box-shadow:none;box-shadow:none;background:#777;color:white}.components-button-group .kt-editor-width-btn.is-primary,.components-button-group .kt-editor-width-btn:focus:not(:disabled):not([aria-disabled=true]){background:#444}.kt-blocks-control-wrap .kt-block-defaults{display:-ms-inline-flexbox;display:inline-flex;padding:4px 10px;font-size:12px;font-weight:600;-ms-flex-align:center;align-items:center;line-height:24px;background:#fff;border:1px solid #ddd;text-align:left;color:#444;width:80%;-webkit-box-shadow:none;box-shadow:none;margin-bottom:10px}.kt-blocks-control-wrap .kt-block-defaults span.kt-block-icon{display:block;height:20px;margin-right:10px}.kt-blocks-control-wrap .kt-block-defaults:hover{background:#f9f9f9}.kt-blocks-control-wrap .kt-block-defaults:focus{-webkit-box-shadow:none;box-shadow:none}.kt-blocks-control-wrap .kt-block-settings{width:16%;display:-ms-inline-flexbox;display:inline-flex;padding:6px 10px;font-weight:600;-ms-flex-align:center;align-items:center;background:#fff;border:1px solid #ddd;text-align:left;color:#555;-webkit-box-shadow:none;box-shadow:none;margin-left:2%;margin-bottom:10px}.kt-blocks-control-wrap .kt-block-settings:hover{background:#f9f9f9}.kt-blocks-control-wrap .kt-block-settings:focus{-webkit-box-shadow:none;box-shadow:none}.kt-block-settings-modal .components-modal__header h1,.kt-block-defaults-modal .components-modal__header h1{font-size:14px;font-weight:bold}.kt-block-defaults-modal button.components-button.kt-defaults-save,.kt-block-settings-modal button.components-button.kt-settings-save{margin-top:10px}@media (min-width: 600px){.kt-block-defaults-modal{width:400px}}.kt-block-defaults-modal p{margin-top:0}.kt-block-defaults-modal .components-color-palette{padding-bottom:5px}.kt-block-defaults-modal .components-color-palette:after{clear:both;display:table;content:''}.kt-block-defaults-modal .components-panel__body .components-base-control{margin-bottom:24px}.kt-block-defaults-modal .components-panel__body:last-child{margin-bottom:-16px}.kt-block-defaults-modal .components-panel__body:first-child{margin-top:16px}.kt-block-defaults-modal .components-panel__body{border:none;border-top:1px solid #e2e4e7;margin:0 -16px}.kt-font-family-modal{min-height:480px}
+ */
+.rfipbtn--green {
+  background-color: #fff;
+  border: 1px solid #81c784; }
+
+.rfipbtn--green:active, .rfipbtn--green:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #66bb6a; }
+
+.rfipbtn--green .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #81c784;
+  background-color: #c8e6c9;
+  color: #2e7d32; }
+
+.rfipbtn--green .rfipbtn__button:hover {
+  background-color: #66bb6a; }
+
+.rfipbtn--green .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #81c784;
+  box-shadow: inset 0 0 10px 0 #81c784; }
+
+.rfipbtn--green .rfipbtn__icon {
+  border: 1px solid #a5d6a7;
+  color: #2e7d32; }
+
+.rfipbtn--green .rfipbtn__icon--empty {
+  color: #81c784; }
+
+.rfipbtn--green .rfipbtn__del {
+  background-color: #a5d6a7; }
+
+.rfipbtn--green .rfipbtn__del:hover {
+  background-color: #81c784; }
+
+.rfipbtn--green .rfipbtn__del:active, .rfipbtn--green .rfipbtn__del:focus {
+  outline: 1px solid #81c784; }
+
+.rfipdropdown--green {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #81c784; }
+
+.rfipdropdown--green input, .rfipdropdown--green select {
+  color: #424242; }
+
+.rfipdropdown--green .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #66bb6a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--green .rfipcategory select:active, .rfipdropdown--green .rfipcategory select:focus {
+  border-bottom-color: #4caf50;
+  -webkit-box-shadow: 0 1px 0 0 #4caf50;
+  box-shadow: 0 1px 0 0 #4caf50;
+  outline: 0 none; }
+
+.rfipdropdown--green .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #66bb6a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--green .rfipicons__cp:active, .rfipdropdown--green .rfipicons__cp:focus {
+  border-bottom-color: #4caf50;
+  -webkit-box-shadow: 0 1px 0 0 #4caf50;
+  box-shadow: 0 1px 0 0 #4caf50;
+  outline: 0 none; }
+
+.rfipdropdown--green .rfipicons__left, .rfipdropdown--green .rfipicons__right {
+  background-color: #a5d6a7;
+  border: 1px solid #a5d6a7;
+  color: #2e7d32; }
+
+.rfipdropdown--green .rfipicons__left:hover, .rfipdropdown--green .rfipicons__right:hover {
+  background-color: #66bb6a;
+  border: 1px solid #66bb6a; }
+
+.rfipdropdown--green .rfipicons__left:active, .rfipdropdown--green .rfipicons__left:focus, .rfipdropdown--green .rfipicons__right:active, .rfipdropdown--green .rfipicons__right:focus {
+  border: 1px solid #66bb6a; }
+
+.rfipdropdown--green .rfipicons__ibox {
+  background-color: #c8e6c9;
+  border: 1px solid #c8e6c9;
+  color: #2e7d32; }
+
+.rfipdropdown--green .rfipicons__ibox:hover {
+  background-color: #66bb6a;
+  border: 1px solid #66bb6a; }
+
+.rfipdropdown--green .rfipicons__ibox:active, .rfipdropdown--green .rfipicons__ibox:focus {
+  border: 1px solid #66bb6a; }
+
+.rfipdropdown--green .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--green .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #a5d6a7; }
+
+.rfipdropdown--green .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #66bb6a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--green .rfipsearch input:active, .rfipdropdown--green .rfipsearch input:focus {
+  border-bottom-color: #4caf50;
+  -webkit-box-shadow: 0 1px 0 0 #4caf50;
+  box-shadow: 0 1px 0 0 #4caf50;
+  outline: 0 none; }
+
+.rfipbtn--bluegrey {
+  background-color: #fff;
+  border: 1px solid #90a4ae; }
+
+.rfipbtn--bluegrey:active, .rfipbtn--bluegrey:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #78909c; }
+
+.rfipbtn--bluegrey .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #90a4ae;
+  background-color: #cfd8dc;
+  color: #37474f; }
+
+.rfipbtn--bluegrey .rfipbtn__button:hover {
+  background-color: #78909c; }
+
+.rfipbtn--bluegrey .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #90a4ae;
+  box-shadow: inset 0 0 10px 0 #90a4ae; }
+
+.rfipbtn--bluegrey .rfipbtn__icon {
+  border: 1px solid #b0bec5;
+  color: #37474f; }
+
+.rfipbtn--bluegrey .rfipbtn__icon--empty {
+  color: #90a4ae; }
+
+.rfipbtn--bluegrey .rfipbtn__del {
+  background-color: #b0bec5; }
+
+.rfipbtn--bluegrey .rfipbtn__del:hover {
+  background-color: #90a4ae; }
+
+.rfipbtn--bluegrey .rfipbtn__del:active, .rfipbtn--bluegrey .rfipbtn__del:focus {
+  outline: 1px solid #90a4ae; }
+
+.rfipdropdown--bluegrey {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #90a4ae; }
+
+.rfipdropdown--bluegrey input, .rfipdropdown--bluegrey select {
+  color: #424242; }
+
+.rfipdropdown--bluegrey .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #78909c;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--bluegrey .rfipcategory select:active, .rfipdropdown--bluegrey .rfipcategory select:focus {
+  border-bottom-color: #607d8b;
+  -webkit-box-shadow: 0 1px 0 0 #607d8b;
+  box-shadow: 0 1px 0 0 #607d8b;
+  outline: 0 none; }
+
+.rfipdropdown--bluegrey .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #78909c;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--bluegrey .rfipicons__cp:active, .rfipdropdown--bluegrey .rfipicons__cp:focus {
+  border-bottom-color: #607d8b;
+  -webkit-box-shadow: 0 1px 0 0 #607d8b;
+  box-shadow: 0 1px 0 0 #607d8b;
+  outline: 0 none; }
+
+.rfipdropdown--bluegrey .rfipicons__left, .rfipdropdown--bluegrey .rfipicons__right {
+  background-color: #b0bec5;
+  border: 1px solid #b0bec5;
+  color: #37474f; }
+
+.rfipdropdown--bluegrey .rfipicons__left:hover, .rfipdropdown--bluegrey .rfipicons__right:hover {
+  background-color: #78909c;
+  border: 1px solid #78909c; }
+
+.rfipdropdown--bluegrey .rfipicons__left:active, .rfipdropdown--bluegrey .rfipicons__left:focus, .rfipdropdown--bluegrey .rfipicons__right:active, .rfipdropdown--bluegrey .rfipicons__right:focus {
+  border: 1px solid #78909c; }
+
+.rfipdropdown--bluegrey .rfipicons__ibox {
+  background-color: #cfd8dc;
+  border: 1px solid #cfd8dc;
+  color: #37474f; }
+
+.rfipdropdown--bluegrey .rfipicons__ibox:hover {
+  background-color: #78909c;
+  border: 1px solid #78909c; }
+
+.rfipdropdown--bluegrey .rfipicons__ibox:active, .rfipdropdown--bluegrey .rfipicons__ibox:focus {
+  border: 1px solid #78909c; }
+
+.rfipdropdown--bluegrey .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--bluegrey .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #b0bec5; }
+
+.rfipdropdown--bluegrey .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #78909c;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--bluegrey .rfipsearch input:active, .rfipdropdown--bluegrey .rfipsearch input:focus {
+  border-bottom-color: #607d8b;
+  -webkit-box-shadow: 0 1px 0 0 #607d8b;
+  box-shadow: 0 1px 0 0 #607d8b;
+  outline: 0 none; }
+
+.rfipbtn--brown {
+  background-color: #fff;
+  border: 1px solid #a1887f; }
+
+.rfipbtn--brown:active, .rfipbtn--brown:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #8d6e63; }
+
+.rfipbtn--brown .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #a1887f;
+  background-color: #d7ccc8;
+  color: #4e342e; }
+
+.rfipbtn--brown .rfipbtn__button:hover {
+  background-color: #8d6e63; }
+
+.rfipbtn--brown .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #a1887f;
+  box-shadow: inset 0 0 10px 0 #a1887f; }
+
+.rfipbtn--brown .rfipbtn__icon {
+  border: 1px solid #bcaaa4;
+  color: #4e342e; }
+
+.rfipbtn--brown .rfipbtn__icon--empty {
+  color: #a1887f; }
+
+.rfipbtn--brown .rfipbtn__del {
+  background-color: #bcaaa4; }
+
+.rfipbtn--brown .rfipbtn__del:hover {
+  background-color: #a1887f; }
+
+.rfipbtn--brown .rfipbtn__del:active, .rfipbtn--brown .rfipbtn__del:focus {
+  outline: 1px solid #a1887f; }
+
+.rfipdropdown--brown {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #a1887f; }
+
+.rfipdropdown--brown input, .rfipdropdown--brown select {
+  color: #424242; }
+
+.rfipdropdown--brown .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #8d6e63;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--brown .rfipcategory select:active, .rfipdropdown--brown .rfipcategory select:focus {
+  border-bottom-color: #795548;
+  -webkit-box-shadow: 0 1px 0 0 #795548;
+  box-shadow: 0 1px 0 0 #795548;
+  outline: 0 none; }
+
+.rfipdropdown--brown .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #8d6e63;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--brown .rfipicons__cp:active, .rfipdropdown--brown .rfipicons__cp:focus {
+  border-bottom-color: #795548;
+  -webkit-box-shadow: 0 1px 0 0 #795548;
+  box-shadow: 0 1px 0 0 #795548;
+  outline: 0 none; }
+
+.rfipdropdown--brown .rfipicons__left, .rfipdropdown--brown .rfipicons__right {
+  background-color: #bcaaa4;
+  border: 1px solid #bcaaa4;
+  color: #4e342e; }
+
+.rfipdropdown--brown .rfipicons__left:hover, .rfipdropdown--brown .rfipicons__right:hover {
+  background-color: #8d6e63;
+  border: 1px solid #8d6e63; }
+
+.rfipdropdown--brown .rfipicons__left:active, .rfipdropdown--brown .rfipicons__left:focus, .rfipdropdown--brown .rfipicons__right:active, .rfipdropdown--brown .rfipicons__right:focus {
+  border: 1px solid #8d6e63; }
+
+.rfipdropdown--brown .rfipicons__ibox {
+  background-color: #d7ccc8;
+  border: 1px solid #d7ccc8;
+  color: #4e342e; }
+
+.rfipdropdown--brown .rfipicons__ibox:hover {
+  background-color: #8d6e63;
+  border: 1px solid #8d6e63; }
+
+.rfipdropdown--brown .rfipicons__ibox:active, .rfipdropdown--brown .rfipicons__ibox:focus {
+  border: 1px solid #8d6e63; }
+
+.rfipdropdown--brown .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--brown .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #bcaaa4; }
+
+.rfipdropdown--brown .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #8d6e63;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--brown .rfipsearch input:active, .rfipdropdown--brown .rfipsearch input:focus {
+  border-bottom-color: #795548;
+  -webkit-box-shadow: 0 1px 0 0 #795548;
+  box-shadow: 0 1px 0 0 #795548;
+  outline: 0 none; }
+
+.rfipbtn--cyan {
+  background-color: #fff;
+  border: 1px solid #4dd0e1; }
+
+.rfipbtn--cyan:active, .rfipbtn--cyan:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #26c6da; }
+
+.rfipbtn--cyan .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #4dd0e1;
+  background-color: #b2ebf2;
+  color: #00838f; }
+
+.rfipbtn--cyan .rfipbtn__button:hover {
+  background-color: #26c6da; }
+
+.rfipbtn--cyan .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #4dd0e1;
+  box-shadow: inset 0 0 10px 0 #4dd0e1; }
+
+.rfipbtn--cyan .rfipbtn__icon {
+  border: 1px solid #80deea;
+  color: #00838f; }
+
+.rfipbtn--cyan .rfipbtn__icon--empty {
+  color: #4dd0e1; }
+
+.rfipbtn--cyan .rfipbtn__del {
+  background-color: #80deea; }
+
+.rfipbtn--cyan .rfipbtn__del:hover {
+  background-color: #4dd0e1; }
+
+.rfipbtn--cyan .rfipbtn__del:active, .rfipbtn--cyan .rfipbtn__del:focus {
+  outline: 1px solid #4dd0e1; }
+
+.rfipdropdown--cyan {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #4dd0e1; }
+
+.rfipdropdown--cyan input, .rfipdropdown--cyan select {
+  color: #424242; }
+
+.rfipdropdown--cyan .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #26c6da;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--cyan .rfipcategory select:active, .rfipdropdown--cyan .rfipcategory select:focus {
+  border-bottom-color: #00bcd4;
+  -webkit-box-shadow: 0 1px 0 0 #00bcd4;
+  box-shadow: 0 1px 0 0 #00bcd4;
+  outline: 0 none; }
+
+.rfipdropdown--cyan .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #26c6da;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--cyan .rfipicons__cp:active, .rfipdropdown--cyan .rfipicons__cp:focus {
+  border-bottom-color: #00bcd4;
+  -webkit-box-shadow: 0 1px 0 0 #00bcd4;
+  box-shadow: 0 1px 0 0 #00bcd4;
+  outline: 0 none; }
+
+.rfipdropdown--cyan .rfipicons__left, .rfipdropdown--cyan .rfipicons__right {
+  background-color: #80deea;
+  border: 1px solid #80deea;
+  color: #00838f; }
+
+.rfipdropdown--cyan .rfipicons__left:hover, .rfipdropdown--cyan .rfipicons__right:hover {
+  background-color: #26c6da;
+  border: 1px solid #26c6da; }
+
+.rfipdropdown--cyan .rfipicons__left:active, .rfipdropdown--cyan .rfipicons__left:focus, .rfipdropdown--cyan .rfipicons__right:active, .rfipdropdown--cyan .rfipicons__right:focus {
+  border: 1px solid #26c6da; }
+
+.rfipdropdown--cyan .rfipicons__ibox {
+  background-color: #b2ebf2;
+  border: 1px solid #b2ebf2;
+  color: #00838f; }
+
+.rfipdropdown--cyan .rfipicons__ibox:hover {
+  background-color: #26c6da;
+  border: 1px solid #26c6da; }
+
+.rfipdropdown--cyan .rfipicons__ibox:active, .rfipdropdown--cyan .rfipicons__ibox:focus {
+  border: 1px solid #26c6da; }
+
+.rfipdropdown--cyan .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--cyan .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #80deea; }
+
+.rfipdropdown--cyan .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #26c6da;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--cyan .rfipsearch input:active, .rfipdropdown--cyan .rfipsearch input:focus {
+  border-bottom-color: #00bcd4;
+  -webkit-box-shadow: 0 1px 0 0 #00bcd4;
+  box-shadow: 0 1px 0 0 #00bcd4;
+  outline: 0 none; }
+
+.rfipbtn--deeporange {
+  background-color: #fff;
+  border: 1px solid #ff8a65; }
+
+.rfipbtn--deeporange:active, .rfipbtn--deeporange:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #ff7043; }
+
+.rfipbtn--deeporange .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #ff8a65;
+  background-color: #ffccbc;
+  color: #d84315; }
+
+.rfipbtn--deeporange .rfipbtn__button:hover {
+  background-color: #ff7043; }
+
+.rfipbtn--deeporange .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #ff8a65;
+  box-shadow: inset 0 0 10px 0 #ff8a65; }
+
+.rfipbtn--deeporange .rfipbtn__icon {
+  border: 1px solid #ffab91;
+  color: #d84315; }
+
+.rfipbtn--deeporange .rfipbtn__icon--empty {
+  color: #ff8a65; }
+
+.rfipbtn--deeporange .rfipbtn__del {
+  background-color: #ffab91; }
+
+.rfipbtn--deeporange .rfipbtn__del:hover {
+  background-color: #ff8a65; }
+
+.rfipbtn--deeporange .rfipbtn__del:active, .rfipbtn--deeporange .rfipbtn__del:focus {
+  outline: 1px solid #ff8a65; }
+
+.rfipdropdown--deeporange {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #ff8a65; }
+
+.rfipdropdown--deeporange input, .rfipdropdown--deeporange select {
+  color: #424242; }
+
+.rfipdropdown--deeporange .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #ff7043;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--deeporange .rfipcategory select:active, .rfipdropdown--deeporange .rfipcategory select:focus {
+  border-bottom-color: #ff5722;
+  -webkit-box-shadow: 0 1px 0 0 #ff5722;
+  box-shadow: 0 1px 0 0 #ff5722;
+  outline: 0 none; }
+
+.rfipdropdown--deeporange .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #ff7043;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--deeporange .rfipicons__cp:active, .rfipdropdown--deeporange .rfipicons__cp:focus {
+  border-bottom-color: #ff5722;
+  -webkit-box-shadow: 0 1px 0 0 #ff5722;
+  box-shadow: 0 1px 0 0 #ff5722;
+  outline: 0 none; }
+
+.rfipdropdown--deeporange .rfipicons__left, .rfipdropdown--deeporange .rfipicons__right {
+  background-color: #ffab91;
+  border: 1px solid #ffab91;
+  color: #d84315; }
+
+.rfipdropdown--deeporange .rfipicons__left:hover, .rfipdropdown--deeporange .rfipicons__right:hover {
+  background-color: #ff7043;
+  border: 1px solid #ff7043; }
+
+.rfipdropdown--deeporange .rfipicons__left:active, .rfipdropdown--deeporange .rfipicons__left:focus, .rfipdropdown--deeporange .rfipicons__right:active, .rfipdropdown--deeporange .rfipicons__right:focus {
+  border: 1px solid #ff7043; }
+
+.rfipdropdown--deeporange .rfipicons__ibox {
+  background-color: #ffccbc;
+  border: 1px solid #ffccbc;
+  color: #d84315; }
+
+.rfipdropdown--deeporange .rfipicons__ibox:hover {
+  background-color: #ff7043;
+  border: 1px solid #ff7043; }
+
+.rfipdropdown--deeporange .rfipicons__ibox:active, .rfipdropdown--deeporange .rfipicons__ibox:focus {
+  border: 1px solid #ff7043; }
+
+.rfipdropdown--deeporange .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--deeporange .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #ffab91; }
+
+.rfipdropdown--deeporange .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #ff7043;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--deeporange .rfipsearch input:active, .rfipdropdown--deeporange .rfipsearch input:focus {
+  border-bottom-color: #ff5722;
+  -webkit-box-shadow: 0 1px 0 0 #ff5722;
+  box-shadow: 0 1px 0 0 #ff5722;
+  outline: 0 none; }
+
+.rfipbtn--deeppurple {
+  background-color: #fff;
+  border: 1px solid #9575cd; }
+
+.rfipbtn--deeppurple:active, .rfipbtn--deeppurple:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #7e57c2; }
+
+.rfipbtn--deeppurple .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #9575cd;
+  background-color: #d1c4e9;
+  color: #4527a0; }
+
+.rfipbtn--deeppurple .rfipbtn__button:hover {
+  background-color: #7e57c2; }
+
+.rfipbtn--deeppurple .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #9575cd;
+  box-shadow: inset 0 0 10px 0 #9575cd; }
+
+.rfipbtn--deeppurple .rfipbtn__icon {
+  border: 1px solid #b39ddb;
+  color: #4527a0; }
+
+.rfipbtn--deeppurple .rfipbtn__icon--empty {
+  color: #9575cd; }
+
+.rfipbtn--deeppurple .rfipbtn__del {
+  background-color: #b39ddb; }
+
+.rfipbtn--deeppurple .rfipbtn__del:hover {
+  background-color: #9575cd; }
+
+.rfipbtn--deeppurple .rfipbtn__del:active, .rfipbtn--deeppurple .rfipbtn__del:focus {
+  outline: 1px solid #9575cd; }
+
+.rfipdropdown--deeppurple {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #9575cd; }
+
+.rfipdropdown--deeppurple input, .rfipdropdown--deeppurple select {
+  color: #424242; }
+
+.rfipdropdown--deeppurple .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #7e57c2;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--deeppurple .rfipcategory select:active, .rfipdropdown--deeppurple .rfipcategory select:focus {
+  border-bottom-color: #673ab7;
+  -webkit-box-shadow: 0 1px 0 0 #673ab7;
+  box-shadow: 0 1px 0 0 #673ab7;
+  outline: 0 none; }
+
+.rfipdropdown--deeppurple .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #7e57c2;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--deeppurple .rfipicons__cp:active, .rfipdropdown--deeppurple .rfipicons__cp:focus {
+  border-bottom-color: #673ab7;
+  -webkit-box-shadow: 0 1px 0 0 #673ab7;
+  box-shadow: 0 1px 0 0 #673ab7;
+  outline: 0 none; }
+
+.rfipdropdown--deeppurple .rfipicons__left, .rfipdropdown--deeppurple .rfipicons__right {
+  background-color: #b39ddb;
+  border: 1px solid #b39ddb;
+  color: #4527a0; }
+
+.rfipdropdown--deeppurple .rfipicons__left:hover, .rfipdropdown--deeppurple .rfipicons__right:hover {
+  background-color: #7e57c2;
+  border: 1px solid #7e57c2; }
+
+.rfipdropdown--deeppurple .rfipicons__left:active, .rfipdropdown--deeppurple .rfipicons__left:focus, .rfipdropdown--deeppurple .rfipicons__right:active, .rfipdropdown--deeppurple .rfipicons__right:focus {
+  border: 1px solid #7e57c2; }
+
+.rfipdropdown--deeppurple .rfipicons__ibox {
+  background-color: #d1c4e9;
+  border: 1px solid #d1c4e9;
+  color: #4527a0; }
+
+.rfipdropdown--deeppurple .rfipicons__ibox:hover {
+  background-color: #7e57c2;
+  border: 1px solid #7e57c2; }
+
+.rfipdropdown--deeppurple .rfipicons__ibox:active, .rfipdropdown--deeppurple .rfipicons__ibox:focus {
+  border: 1px solid #7e57c2; }
+
+.rfipdropdown--deeppurple .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--deeppurple .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #b39ddb; }
+
+.rfipdropdown--deeppurple .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #7e57c2;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--deeppurple .rfipsearch input:active, .rfipdropdown--deeppurple .rfipsearch input:focus {
+  border-bottom-color: #673ab7;
+  -webkit-box-shadow: 0 1px 0 0 #673ab7;
+  box-shadow: 0 1px 0 0 #673ab7;
+  outline: 0 none; }
+
+.rfipbtn--default {
+  background-color: #fff;
+  border: 1px solid #e0e0e0; }
+
+.rfipbtn--default:active, .rfipbtn--default:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #bdbdbd; }
+
+.rfipbtn--default .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #e0e0e0;
+  background-color: #f5f5f5;
+  color: #424242; }
+
+.rfipbtn--default .rfipbtn__button:hover {
+  background-color: #bdbdbd; }
+
+.rfipbtn--default .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #e0e0e0;
+  box-shadow: inset 0 0 10px 0 #e0e0e0; }
+
+.rfipbtn--default .rfipbtn__icon {
+  border: 1px solid #eee;
+  color: #424242; }
+
+.rfipbtn--default .rfipbtn__icon--empty {
+  color: #e0e0e0; }
+
+.rfipbtn--default .rfipbtn__del {
+  background-color: #eee; }
+
+.rfipbtn--default .rfipbtn__del:hover {
+  background-color: #e0e0e0; }
+
+.rfipbtn--default .rfipbtn__del:active, .rfipbtn--default .rfipbtn__del:focus {
+  outline: 1px solid #e0e0e0; }
+
+.rfipdropdown--default {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #e0e0e0; }
+
+.rfipdropdown--default input, .rfipdropdown--default select {
+  color: #424242; }
+
+.rfipdropdown--default .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #bdbdbd;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--default .rfipcategory select:active, .rfipdropdown--default .rfipcategory select:focus {
+  border-bottom-color: #9e9e9e;
+  -webkit-box-shadow: 0 1px 0 0 #9e9e9e;
+  box-shadow: 0 1px 0 0 #9e9e9e;
+  outline: 0 none; }
+
+.rfipdropdown--default .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #bdbdbd;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--default .rfipicons__cp:active, .rfipdropdown--default .rfipicons__cp:focus {
+  border-bottom-color: #9e9e9e;
+  -webkit-box-shadow: 0 1px 0 0 #9e9e9e;
+  box-shadow: 0 1px 0 0 #9e9e9e;
+  outline: 0 none; }
+
+.rfipdropdown--default .rfipicons__left, .rfipdropdown--default .rfipicons__right {
+  background-color: #eee;
+  border: 1px solid #eee;
+  color: #424242; }
+
+.rfipdropdown--default .rfipicons__left:hover, .rfipdropdown--default .rfipicons__right:hover {
+  background-color: #bdbdbd;
+  border: 1px solid #bdbdbd; }
+
+.rfipdropdown--default .rfipicons__left:active, .rfipdropdown--default .rfipicons__left:focus, .rfipdropdown--default .rfipicons__right:active, .rfipdropdown--default .rfipicons__right:focus {
+  border: 1px solid #bdbdbd; }
+
+.rfipdropdown--default .rfipicons__ibox {
+  background-color: #f5f5f5;
+  border: 1px solid #f5f5f5;
+  color: #424242; }
+
+.rfipdropdown--default .rfipicons__ibox:hover {
+  background-color: #bdbdbd;
+  border: 1px solid #bdbdbd; }
+
+.rfipdropdown--default .rfipicons__ibox:active, .rfipdropdown--default .rfipicons__ibox:focus {
+  border: 1px solid #bdbdbd; }
+
+.rfipdropdown--default .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--default .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #eee; }
+
+.rfipdropdown--default .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #bdbdbd;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--default .rfipsearch input:active, .rfipdropdown--default .rfipsearch input:focus {
+  border-bottom-color: #9e9e9e;
+  -webkit-box-shadow: 0 1px 0 0 #9e9e9e;
+  box-shadow: 0 1px 0 0 #9e9e9e;
+  outline: 0 none; }
+
+.rfipbtn--blue {
+  background-color: #fff;
+  border: 1px solid #64b5f6; }
+
+.rfipbtn--blue:active, .rfipbtn--blue:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #42a5f5; }
+
+.rfipbtn--blue .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #64b5f6;
+  background-color: #bbdefb;
+  color: #1565c0; }
+
+.rfipbtn--blue .rfipbtn__button:hover {
+  background-color: #42a5f5; }
+
+.rfipbtn--blue .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #64b5f6;
+  box-shadow: inset 0 0 10px 0 #64b5f6; }
+
+.rfipbtn--blue .rfipbtn__icon {
+  border: 1px solid #90caf9;
+  color: #1565c0; }
+
+.rfipbtn--blue .rfipbtn__icon--empty {
+  color: #64b5f6; }
+
+.rfipbtn--blue .rfipbtn__del {
+  background-color: #90caf9; }
+
+.rfipbtn--blue .rfipbtn__del:hover {
+  background-color: #64b5f6; }
+
+.rfipbtn--blue .rfipbtn__del:active, .rfipbtn--blue .rfipbtn__del:focus {
+  outline: 1px solid #64b5f6; }
+
+.rfipdropdown--blue {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #64b5f6; }
+
+.rfipdropdown--blue input, .rfipdropdown--blue select {
+  color: #424242; }
+
+.rfipdropdown--blue .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #42a5f5;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--blue .rfipcategory select:active, .rfipdropdown--blue .rfipcategory select:focus {
+  border-bottom-color: #2196f3;
+  -webkit-box-shadow: 0 1px 0 0 #2196f3;
+  box-shadow: 0 1px 0 0 #2196f3;
+  outline: 0 none; }
+
+.rfipdropdown--blue .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #42a5f5;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--blue .rfipicons__cp:active, .rfipdropdown--blue .rfipicons__cp:focus {
+  border-bottom-color: #2196f3;
+  -webkit-box-shadow: 0 1px 0 0 #2196f3;
+  box-shadow: 0 1px 0 0 #2196f3;
+  outline: 0 none; }
+
+.rfipdropdown--blue .rfipicons__left, .rfipdropdown--blue .rfipicons__right {
+  background-color: #90caf9;
+  border: 1px solid #90caf9;
+  color: #1565c0; }
+
+.rfipdropdown--blue .rfipicons__left:hover, .rfipdropdown--blue .rfipicons__right:hover {
+  background-color: #42a5f5;
+  border: 1px solid #42a5f5; }
+
+.rfipdropdown--blue .rfipicons__left:active, .rfipdropdown--blue .rfipicons__left:focus, .rfipdropdown--blue .rfipicons__right:active, .rfipdropdown--blue .rfipicons__right:focus {
+  border: 1px solid #42a5f5; }
+
+.rfipdropdown--blue .rfipicons__ibox {
+  background-color: #bbdefb;
+  border: 1px solid #bbdefb;
+  color: #1565c0; }
+
+.rfipdropdown--blue .rfipicons__ibox:hover {
+  background-color: #42a5f5;
+  border: 1px solid #42a5f5; }
+
+.rfipdropdown--blue .rfipicons__ibox:active, .rfipdropdown--blue .rfipicons__ibox:focus {
+  border: 1px solid #42a5f5; }
+
+.rfipdropdown--blue .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--blue .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #90caf9; }
+
+.rfipdropdown--blue .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #42a5f5;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--blue .rfipsearch input:active, .rfipdropdown--blue .rfipsearch input:focus {
+  border-bottom-color: #2196f3;
+  -webkit-box-shadow: 0 1px 0 0 #2196f3;
+  box-shadow: 0 1px 0 0 #2196f3;
+  outline: 0 none; }
+
+.rfipbtn--indigo {
+  background-color: #fff;
+  border: 1px solid #7986cb; }
+
+.rfipbtn--indigo:active, .rfipbtn--indigo:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #5c6bc0; }
+
+.rfipbtn--indigo .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #7986cb;
+  background-color: #c5cae9;
+  color: #283593; }
+
+.rfipbtn--indigo .rfipbtn__button:hover {
+  background-color: #5c6bc0; }
+
+.rfipbtn--indigo .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #7986cb;
+  box-shadow: inset 0 0 10px 0 #7986cb; }
+
+.rfipbtn--indigo .rfipbtn__icon {
+  border: 1px solid #9fa8da;
+  color: #283593; }
+
+.rfipbtn--indigo .rfipbtn__icon--empty {
+  color: #7986cb; }
+
+.rfipbtn--indigo .rfipbtn__del {
+  background-color: #9fa8da; }
+
+.rfipbtn--indigo .rfipbtn__del:hover {
+  background-color: #7986cb; }
+
+.rfipbtn--indigo .rfipbtn__del:active, .rfipbtn--indigo .rfipbtn__del:focus {
+  outline: 1px solid #7986cb; }
+
+.rfipdropdown--indigo {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #7986cb; }
+
+.rfipdropdown--indigo input, .rfipdropdown--indigo select {
+  color: #424242; }
+
+.rfipdropdown--indigo .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #5c6bc0;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--indigo .rfipcategory select:active, .rfipdropdown--indigo .rfipcategory select:focus {
+  border-bottom-color: #3f51b5;
+  -webkit-box-shadow: 0 1px 0 0 #3f51b5;
+  box-shadow: 0 1px 0 0 #3f51b5;
+  outline: 0 none; }
+
+.rfipdropdown--indigo .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #5c6bc0;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--indigo .rfipicons__cp:active, .rfipdropdown--indigo .rfipicons__cp:focus {
+  border-bottom-color: #3f51b5;
+  -webkit-box-shadow: 0 1px 0 0 #3f51b5;
+  box-shadow: 0 1px 0 0 #3f51b5;
+  outline: 0 none; }
+
+.rfipdropdown--indigo .rfipicons__left, .rfipdropdown--indigo .rfipicons__right {
+  background-color: #9fa8da;
+  border: 1px solid #9fa8da;
+  color: #283593; }
+
+.rfipdropdown--indigo .rfipicons__left:hover, .rfipdropdown--indigo .rfipicons__right:hover {
+  background-color: #5c6bc0;
+  border: 1px solid #5c6bc0; }
+
+.rfipdropdown--indigo .rfipicons__left:active, .rfipdropdown--indigo .rfipicons__left:focus, .rfipdropdown--indigo .rfipicons__right:active, .rfipdropdown--indigo .rfipicons__right:focus {
+  border: 1px solid #5c6bc0; }
+
+.rfipdropdown--indigo .rfipicons__ibox {
+  background-color: #c5cae9;
+  border: 1px solid #c5cae9;
+  color: #283593; }
+
+.rfipdropdown--indigo .rfipicons__ibox:hover {
+  background-color: #5c6bc0;
+  border: 1px solid #5c6bc0; }
+
+.rfipdropdown--indigo .rfipicons__ibox:active, .rfipdropdown--indigo .rfipicons__ibox:focus {
+  border: 1px solid #5c6bc0; }
+
+.rfipdropdown--indigo .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--indigo .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #9fa8da; }
+
+.rfipdropdown--indigo .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #5c6bc0;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--indigo .rfipsearch input:active, .rfipdropdown--indigo .rfipsearch input:focus {
+  border-bottom-color: #3f51b5;
+  -webkit-box-shadow: 0 1px 0 0 #3f51b5;
+  box-shadow: 0 1px 0 0 #3f51b5;
+  outline: 0 none; }
+
+.rfipbtn--lightblue {
+  background-color: #fff;
+  border: 1px solid #4fc3f7; }
+
+.rfipbtn--lightblue:active, .rfipbtn--lightblue:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #29b6f6; }
+
+.rfipbtn--lightblue .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #4fc3f7;
+  background-color: #b3e5fc;
+  color: #0277bd; }
+
+.rfipbtn--lightblue .rfipbtn__button:hover {
+  background-color: #29b6f6; }
+
+.rfipbtn--lightblue .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #4fc3f7;
+  box-shadow: inset 0 0 10px 0 #4fc3f7; }
+
+.rfipbtn--lightblue .rfipbtn__icon {
+  border: 1px solid #81d4fa;
+  color: #0277bd; }
+
+.rfipbtn--lightblue .rfipbtn__icon--empty {
+  color: #4fc3f7; }
+
+.rfipbtn--lightblue .rfipbtn__del {
+  background-color: #81d4fa; }
+
+.rfipbtn--lightblue .rfipbtn__del:hover {
+  background-color: #4fc3f7; }
+
+.rfipbtn--lightblue .rfipbtn__del:active, .rfipbtn--lightblue .rfipbtn__del:focus {
+  outline: 1px solid #4fc3f7; }
+
+.rfipdropdown--lightblue {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #4fc3f7; }
+
+.rfipdropdown--lightblue input, .rfipdropdown--lightblue select {
+  color: #424242; }
+
+.rfipdropdown--lightblue .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #29b6f6;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--lightblue .rfipcategory select:active, .rfipdropdown--lightblue .rfipcategory select:focus {
+  border-bottom-color: #03a9f4;
+  -webkit-box-shadow: 0 1px 0 0 #03a9f4;
+  box-shadow: 0 1px 0 0 #03a9f4;
+  outline: 0 none; }
+
+.rfipdropdown--lightblue .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #29b6f6;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--lightblue .rfipicons__cp:active, .rfipdropdown--lightblue .rfipicons__cp:focus {
+  border-bottom-color: #03a9f4;
+  -webkit-box-shadow: 0 1px 0 0 #03a9f4;
+  box-shadow: 0 1px 0 0 #03a9f4;
+  outline: 0 none; }
+
+.rfipdropdown--lightblue .rfipicons__left, .rfipdropdown--lightblue .rfipicons__right {
+  background-color: #81d4fa;
+  border: 1px solid #81d4fa;
+  color: #0277bd; }
+
+.rfipdropdown--lightblue .rfipicons__left:hover, .rfipdropdown--lightblue .rfipicons__right:hover {
+  background-color: #29b6f6;
+  border: 1px solid #29b6f6; }
+
+.rfipdropdown--lightblue .rfipicons__left:active, .rfipdropdown--lightblue .rfipicons__left:focus, .rfipdropdown--lightblue .rfipicons__right:active, .rfipdropdown--lightblue .rfipicons__right:focus {
+  border: 1px solid #29b6f6; }
+
+.rfipdropdown--lightblue .rfipicons__ibox {
+  background-color: #b3e5fc;
+  border: 1px solid #b3e5fc;
+  color: #0277bd; }
+
+.rfipdropdown--lightblue .rfipicons__ibox:hover {
+  background-color: #29b6f6;
+  border: 1px solid #29b6f6; }
+
+.rfipdropdown--lightblue .rfipicons__ibox:active, .rfipdropdown--lightblue .rfipicons__ibox:focus {
+  border: 1px solid #29b6f6; }
+
+.rfipdropdown--lightblue .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--lightblue .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #81d4fa; }
+
+.rfipdropdown--lightblue .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #29b6f6;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--lightblue .rfipsearch input:active, .rfipdropdown--lightblue .rfipsearch input:focus {
+  border-bottom-color: #03a9f4;
+  -webkit-box-shadow: 0 1px 0 0 #03a9f4;
+  box-shadow: 0 1px 0 0 #03a9f4;
+  outline: 0 none; }
+
+.rfipbtn--pink {
+  background-color: #fff;
+  border: 1px solid #f06292; }
+
+.rfipbtn--pink:active, .rfipbtn--pink:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #ec407a; }
+
+.rfipbtn--pink .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #f06292;
+  background-color: #f8bbd0;
+  color: #ad1457; }
+
+.rfipbtn--pink .rfipbtn__button:hover {
+  background-color: #ec407a; }
+
+.rfipbtn--pink .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #f06292;
+  box-shadow: inset 0 0 10px 0 #f06292; }
+
+.rfipbtn--pink .rfipbtn__icon {
+  border: 1px solid #f48fb1;
+  color: #ad1457; }
+
+.rfipbtn--pink .rfipbtn__icon--empty {
+  color: #f06292; }
+
+.rfipbtn--pink .rfipbtn__del {
+  background-color: #f48fb1; }
+
+.rfipbtn--pink .rfipbtn__del:hover {
+  background-color: #f06292; }
+
+.rfipbtn--pink .rfipbtn__del:active, .rfipbtn--pink .rfipbtn__del:focus {
+  outline: 1px solid #f06292; }
+
+.rfipdropdown--pink {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #f06292; }
+
+.rfipdropdown--pink input, .rfipdropdown--pink select {
+  color: #424242; }
+
+.rfipdropdown--pink .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #ec407a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--pink .rfipcategory select:active, .rfipdropdown--pink .rfipcategory select:focus {
+  border-bottom-color: #e91e63;
+  -webkit-box-shadow: 0 1px 0 0 #e91e63;
+  box-shadow: 0 1px 0 0 #e91e63;
+  outline: 0 none; }
+
+.rfipdropdown--pink .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #ec407a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--pink .rfipicons__cp:active, .rfipdropdown--pink .rfipicons__cp:focus {
+  border-bottom-color: #e91e63;
+  -webkit-box-shadow: 0 1px 0 0 #e91e63;
+  box-shadow: 0 1px 0 0 #e91e63;
+  outline: 0 none; }
+
+.rfipdropdown--pink .rfipicons__left, .rfipdropdown--pink .rfipicons__right {
+  background-color: #f48fb1;
+  border: 1px solid #f48fb1;
+  color: #ad1457; }
+
+.rfipdropdown--pink .rfipicons__left:hover, .rfipdropdown--pink .rfipicons__right:hover {
+  background-color: #ec407a;
+  border: 1px solid #ec407a; }
+
+.rfipdropdown--pink .rfipicons__left:active, .rfipdropdown--pink .rfipicons__left:focus, .rfipdropdown--pink .rfipicons__right:active, .rfipdropdown--pink .rfipicons__right:focus {
+  border: 1px solid #ec407a; }
+
+.rfipdropdown--pink .rfipicons__ibox {
+  background-color: #f8bbd0;
+  border: 1px solid #f8bbd0;
+  color: #ad1457; }
+
+.rfipdropdown--pink .rfipicons__ibox:hover {
+  background-color: #ec407a;
+  border: 1px solid #ec407a; }
+
+.rfipdropdown--pink .rfipicons__ibox:active, .rfipdropdown--pink .rfipicons__ibox:focus {
+  border: 1px solid #ec407a; }
+
+.rfipdropdown--pink .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--pink .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #f48fb1; }
+
+.rfipdropdown--pink .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #ec407a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--pink .rfipsearch input:active, .rfipdropdown--pink .rfipsearch input:focus {
+  border-bottom-color: #e91e63;
+  -webkit-box-shadow: 0 1px 0 0 #e91e63;
+  box-shadow: 0 1px 0 0 #e91e63;
+  outline: 0 none; }
+
+.rfipbtn--orange {
+  background-color: #fff;
+  border: 1px solid #ffb74d; }
+
+.rfipbtn--orange:active, .rfipbtn--orange:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #ffa726; }
+
+.rfipbtn--orange .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #ffb74d;
+  background-color: #ffe0b2;
+  color: #ef6c00; }
+
+.rfipbtn--orange .rfipbtn__button:hover {
+  background-color: #ffa726; }
+
+.rfipbtn--orange .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #ffb74d;
+  box-shadow: inset 0 0 10px 0 #ffb74d; }
+
+.rfipbtn--orange .rfipbtn__icon {
+  border: 1px solid #ffcc80;
+  color: #ef6c00; }
+
+.rfipbtn--orange .rfipbtn__icon--empty {
+  color: #ffb74d; }
+
+.rfipbtn--orange .rfipbtn__del {
+  background-color: #ffcc80; }
+
+.rfipbtn--orange .rfipbtn__del:hover {
+  background-color: #ffb74d; }
+
+.rfipbtn--orange .rfipbtn__del:active, .rfipbtn--orange .rfipbtn__del:focus {
+  outline: 1px solid #ffb74d; }
+
+.rfipdropdown--orange {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #ffb74d; }
+
+.rfipdropdown--orange input, .rfipdropdown--orange select {
+  color: #424242; }
+
+.rfipdropdown--orange .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #ffa726;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--orange .rfipcategory select:active, .rfipdropdown--orange .rfipcategory select:focus {
+  border-bottom-color: #ff9800;
+  -webkit-box-shadow: 0 1px 0 0 #ff9800;
+  box-shadow: 0 1px 0 0 #ff9800;
+  outline: 0 none; }
+
+.rfipdropdown--orange .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #ffa726;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--orange .rfipicons__cp:active, .rfipdropdown--orange .rfipicons__cp:focus {
+  border-bottom-color: #ff9800;
+  -webkit-box-shadow: 0 1px 0 0 #ff9800;
+  box-shadow: 0 1px 0 0 #ff9800;
+  outline: 0 none; }
+
+.rfipdropdown--orange .rfipicons__left, .rfipdropdown--orange .rfipicons__right {
+  background-color: #ffcc80;
+  border: 1px solid #ffcc80;
+  color: #ef6c00; }
+
+.rfipdropdown--orange .rfipicons__left:hover, .rfipdropdown--orange .rfipicons__right:hover {
+  background-color: #ffa726;
+  border: 1px solid #ffa726; }
+
+.rfipdropdown--orange .rfipicons__left:active, .rfipdropdown--orange .rfipicons__left:focus, .rfipdropdown--orange .rfipicons__right:active, .rfipdropdown--orange .rfipicons__right:focus {
+  border: 1px solid #ffa726; }
+
+.rfipdropdown--orange .rfipicons__ibox {
+  background-color: #ffe0b2;
+  border: 1px solid #ffe0b2;
+  color: #ef6c00; }
+
+.rfipdropdown--orange .rfipicons__ibox:hover {
+  background-color: #ffa726;
+  border: 1px solid #ffa726; }
+
+.rfipdropdown--orange .rfipicons__ibox:active, .rfipdropdown--orange .rfipicons__ibox:focus {
+  border: 1px solid #ffa726; }
+
+.rfipdropdown--orange .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--orange .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #ffcc80; }
+
+.rfipdropdown--orange .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #ffa726;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--orange .rfipsearch input:active, .rfipdropdown--orange .rfipsearch input:focus {
+  border-bottom-color: #ff9800;
+  -webkit-box-shadow: 0 1px 0 0 #ff9800;
+  box-shadow: 0 1px 0 0 #ff9800;
+  outline: 0 none; }
+
+.rfipbtn--purple {
+  background-color: #fff;
+  border: 1px solid #ba68c8; }
+
+.rfipbtn--purple:active, .rfipbtn--purple:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #ab47bc; }
+
+.rfipbtn--purple .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #ba68c8;
+  background-color: #e1bee7;
+  color: #6a1b9a; }
+
+.rfipbtn--purple .rfipbtn__button:hover {
+  background-color: #ab47bc; }
+
+.rfipbtn--purple .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #ba68c8;
+  box-shadow: inset 0 0 10px 0 #ba68c8; }
+
+.rfipbtn--purple .rfipbtn__icon {
+  border: 1px solid #ce93d8;
+  color: #6a1b9a; }
+
+.rfipbtn--purple .rfipbtn__icon--empty {
+  color: #ba68c8; }
+
+.rfipbtn--purple .rfipbtn__del {
+  background-color: #ce93d8; }
+
+.rfipbtn--purple .rfipbtn__del:hover {
+  background-color: #ba68c8; }
+
+.rfipbtn--purple .rfipbtn__del:active, .rfipbtn--purple .rfipbtn__del:focus {
+  outline: 1px solid #ba68c8; }
+
+.rfipdropdown--purple {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #ba68c8; }
+
+.rfipdropdown--purple input, .rfipdropdown--purple select {
+  color: #424242; }
+
+.rfipdropdown--purple .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #ab47bc;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--purple .rfipcategory select:active, .rfipdropdown--purple .rfipcategory select:focus {
+  border-bottom-color: #9c27b0;
+  -webkit-box-shadow: 0 1px 0 0 #9c27b0;
+  box-shadow: 0 1px 0 0 #9c27b0;
+  outline: 0 none; }
+
+.rfipdropdown--purple .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #ab47bc;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--purple .rfipicons__cp:active, .rfipdropdown--purple .rfipicons__cp:focus {
+  border-bottom-color: #9c27b0;
+  -webkit-box-shadow: 0 1px 0 0 #9c27b0;
+  box-shadow: 0 1px 0 0 #9c27b0;
+  outline: 0 none; }
+
+.rfipdropdown--purple .rfipicons__left, .rfipdropdown--purple .rfipicons__right {
+  background-color: #ce93d8;
+  border: 1px solid #ce93d8;
+  color: #6a1b9a; }
+
+.rfipdropdown--purple .rfipicons__left:hover, .rfipdropdown--purple .rfipicons__right:hover {
+  background-color: #ab47bc;
+  border: 1px solid #ab47bc; }
+
+.rfipdropdown--purple .rfipicons__left:active, .rfipdropdown--purple .rfipicons__left:focus, .rfipdropdown--purple .rfipicons__right:active, .rfipdropdown--purple .rfipicons__right:focus {
+  border: 1px solid #ab47bc; }
+
+.rfipdropdown--purple .rfipicons__ibox {
+  background-color: #e1bee7;
+  border: 1px solid #e1bee7;
+  color: #6a1b9a; }
+
+.rfipdropdown--purple .rfipicons__ibox:hover {
+  background-color: #ab47bc;
+  border: 1px solid #ab47bc; }
+
+.rfipdropdown--purple .rfipicons__ibox:active, .rfipdropdown--purple .rfipicons__ibox:focus {
+  border: 1px solid #ab47bc; }
+
+.rfipdropdown--purple .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--purple .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #ce93d8; }
+
+.rfipdropdown--purple .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #ab47bc;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--purple .rfipsearch input:active, .rfipdropdown--purple .rfipsearch input:focus {
+  border-bottom-color: #9c27b0;
+  -webkit-box-shadow: 0 1px 0 0 #9c27b0;
+  box-shadow: 0 1px 0 0 #9c27b0;
+  outline: 0 none; }
+
+.rfipbtn--red {
+  background-color: #fff;
+  border: 1px solid #e57373; }
+
+.rfipbtn--red:active, .rfipbtn--red:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #ef5350; }
+
+.rfipbtn--red .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #e57373;
+  background-color: #ffcdd2;
+  color: #c62828; }
+
+.rfipbtn--red .rfipbtn__button:hover {
+  background-color: #ef5350; }
+
+.rfipbtn--red .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #e57373;
+  box-shadow: inset 0 0 10px 0 #e57373; }
+
+.rfipbtn--red .rfipbtn__icon {
+  border: 1px solid #ef9a9a;
+  color: #c62828; }
+
+.rfipbtn--red .rfipbtn__icon--empty {
+  color: #e57373; }
+
+.rfipbtn--red .rfipbtn__del {
+  background-color: #ef9a9a; }
+
+.rfipbtn--red .rfipbtn__del:hover {
+  background-color: #e57373; }
+
+.rfipbtn--red .rfipbtn__del:active, .rfipbtn--red .rfipbtn__del:focus {
+  outline: 1px solid #e57373; }
+
+.rfipdropdown--red {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #e57373; }
+
+.rfipdropdown--red input, .rfipdropdown--red select {
+  color: #424242; }
+
+.rfipdropdown--red .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #ef5350;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--red .rfipcategory select:active, .rfipdropdown--red .rfipcategory select:focus {
+  border-bottom-color: #f44336;
+  -webkit-box-shadow: 0 1px 0 0 #f44336;
+  box-shadow: 0 1px 0 0 #f44336;
+  outline: 0 none; }
+
+.rfipdropdown--red .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #ef5350;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--red .rfipicons__cp:active, .rfipdropdown--red .rfipicons__cp:focus {
+  border-bottom-color: #f44336;
+  -webkit-box-shadow: 0 1px 0 0 #f44336;
+  box-shadow: 0 1px 0 0 #f44336;
+  outline: 0 none; }
+
+.rfipdropdown--red .rfipicons__left, .rfipdropdown--red .rfipicons__right {
+  background-color: #ef9a9a;
+  border: 1px solid #ef9a9a;
+  color: #c62828; }
+
+.rfipdropdown--red .rfipicons__left:hover, .rfipdropdown--red .rfipicons__right:hover {
+  background-color: #ef5350;
+  border: 1px solid #ef5350; }
+
+.rfipdropdown--red .rfipicons__left:active, .rfipdropdown--red .rfipicons__left:focus, .rfipdropdown--red .rfipicons__right:active, .rfipdropdown--red .rfipicons__right:focus {
+  border: 1px solid #ef5350; }
+
+.rfipdropdown--red .rfipicons__ibox {
+  background-color: #ffcdd2;
+  border: 1px solid #ffcdd2;
+  color: #c62828; }
+
+.rfipdropdown--red .rfipicons__ibox:hover {
+  background-color: #ef5350;
+  border: 1px solid #ef5350; }
+
+.rfipdropdown--red .rfipicons__ibox:active, .rfipdropdown--red .rfipicons__ibox:focus {
+  border: 1px solid #ef5350; }
+
+.rfipdropdown--red .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--red .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #ef9a9a; }
+
+.rfipdropdown--red .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #ef5350;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--red .rfipsearch input:active, .rfipdropdown--red .rfipsearch input:focus {
+  border-bottom-color: #f44336;
+  -webkit-box-shadow: 0 1px 0 0 #f44336;
+  box-shadow: 0 1px 0 0 #f44336;
+  outline: 0 none; }
+
+.rfipbtn--teal {
+  background-color: #fff;
+  border: 1px solid #4db6ac; }
+
+.rfipbtn--teal:active, .rfipbtn--teal:focus {
+  -webkit-box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1.5px 4px rgba(0, 0, 0, 0.24), 0 1.5px 6px rgba(0, 0, 0, 0.12);
+  border: 1px solid #26a69a; }
+
+.rfipbtn--teal .rfipbtn__button {
+  border: 0 none transparent;
+  border-left: 1px solid #4db6ac;
+  background-color: #b2dfdb;
+  color: #00695c; }
+
+.rfipbtn--teal .rfipbtn__button:hover {
+  background-color: #26a69a; }
+
+.rfipbtn--teal .rfipbtn__button:active {
+  -webkit-box-shadow: inset 0 0 10px 0 #4db6ac;
+  box-shadow: inset 0 0 10px 0 #4db6ac; }
+
+.rfipbtn--teal .rfipbtn__icon {
+  border: 1px solid #80cbc4;
+  color: #00695c; }
+
+.rfipbtn--teal .rfipbtn__icon--empty {
+  color: #4db6ac; }
+
+.rfipbtn--teal .rfipbtn__del {
+  background-color: #80cbc4; }
+
+.rfipbtn--teal .rfipbtn__del:hover {
+  background-color: #4db6ac; }
+
+.rfipbtn--teal .rfipbtn__del:active, .rfipbtn--teal .rfipbtn__del:focus {
+  outline: 1px solid #4db6ac; }
+
+.rfipdropdown--teal {
+  -webkit-box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
+  color: #424242;
+  background-color: #fff;
+  border: 1px solid #4db6ac; }
+
+.rfipdropdown--teal input, .rfipdropdown--teal select {
+  color: #424242; }
+
+.rfipdropdown--teal .rfipcategory select {
+  background-color: #fff;
+  border: 0 none;
+  border-bottom: 1px solid #26a69a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--teal .rfipcategory select:active, .rfipdropdown--teal .rfipcategory select:focus {
+  border-bottom-color: #009688;
+  -webkit-box-shadow: 0 1px 0 0 #009688;
+  box-shadow: 0 1px 0 0 #009688;
+  outline: 0 none; }
+
+.rfipdropdown--teal .rfipicons__cp {
+  border: 0 none;
+  border-bottom: 1px solid #26a69a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--teal .rfipicons__cp:active, .rfipdropdown--teal .rfipicons__cp:focus {
+  border-bottom-color: #009688;
+  -webkit-box-shadow: 0 1px 0 0 #009688;
+  box-shadow: 0 1px 0 0 #009688;
+  outline: 0 none; }
+
+.rfipdropdown--teal .rfipicons__left, .rfipdropdown--teal .rfipicons__right {
+  background-color: #80cbc4;
+  border: 1px solid #80cbc4;
+  color: #00695c; }
+
+.rfipdropdown--teal .rfipicons__left:hover, .rfipdropdown--teal .rfipicons__right:hover {
+  background-color: #26a69a;
+  border: 1px solid #26a69a; }
+
+.rfipdropdown--teal .rfipicons__left:active, .rfipdropdown--teal .rfipicons__left:focus, .rfipdropdown--teal .rfipicons__right:active, .rfipdropdown--teal .rfipicons__right:focus {
+  border: 1px solid #26a69a; }
+
+.rfipdropdown--teal .rfipicons__ibox {
+  background-color: #b2dfdb;
+  border: 1px solid #b2dfdb;
+  color: #00695c; }
+
+.rfipdropdown--teal .rfipicons__ibox:hover {
+  background-color: #26a69a;
+  border: 1px solid #26a69a; }
+
+.rfipdropdown--teal .rfipicons__ibox:active, .rfipdropdown--teal .rfipicons__ibox:focus {
+  border: 1px solid #26a69a; }
+
+.rfipdropdown--teal .rfipicons__ibox--error {
+  color: #ef9a9a; }
+
+.rfipdropdown--teal .rfipicons__icon--selected .rfipicons__ibox {
+  background-color: #80cbc4; }
+
+.rfipdropdown--teal .rfipsearch input {
+  border: 0 none;
+  border-bottom: 1px solid #26a69a;
+  -webkit-transition: border .25s,-webkit-box-shadow .25s;
+  transition: border .25s,-webkit-box-shadow .25s;
+  -o-transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s;
+  transition: box-shadow .25s,border .25s,-webkit-box-shadow .25s; }
+
+.rfipdropdown--teal .rfipsearch input:active, .rfipdropdown--teal .rfipsearch input:focus {
+  border-bottom-color: #009688;
+  -webkit-box-shadow: 0 1px 0 0 #009688;
+  box-shadow: 0 1px 0 0 #009688;
+  outline: 0 none; }
+
+.rfipbtn--default .rfipbtn__icon {
+  border: 0;
+  height: 40px; }
+
+.rfipbtn--default .rfipbtn__del {
+  height: 18px; }
+
+.rfipicons__icon svg[fill="none"] {
+  fill: none !important; }
+
+.rfipbtn__elm svg[fill="none"] {
+  fill: none !important; }
+
+[class^=fipicon-] {
+  font-style: normal;
+  font-weight: 400;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
+
+i.fipicon-angle-down:before {
+  content: "\f140";
+  font-family: dashicons; }
+
+i.fipicon-angle-up:before {
+  content: "\f142";
+  font-family: dashicons; }
+
+i.fipicon-angle-right:before {
+  content: "\f345";
+  font-family: dashicons; }
+
+i.fipicon-angle-left:before {
+  content: "\f341";
+  font-family: dashicons; }
+
+.kt-svg-icon-wrap {
+  display: inline-block; }
+
+.kt-svg-style-stacked .kt-svg-icon {
+  border: 0px solid #444444; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.edit-post-sidebar .typography-family-select-form-row input[type=text], .kt-block-defaults-modal .typography-family-select-form-row input[type=text], .components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row input[type=text] {
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.edit-post-sidebar .typography-family-select-form-row, .kt-block-defaults-modal .typography-family-select-form-row {
+  margin-bottom: 10px;
+  z-index: 200;
+  position: relative; }
+
+.components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row {
+  z-index: 200;
+  position: relative;
+  border-left: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  display: block;
+  overflow: inherit;
+  -webkit-transition: none;
+  -o-transition: none;
+  transition: none;
+  width: 100%; }
+
+.kt-font-family-icon svg path {
+  fill: #555d66; }
+
+.components-popover.kt-popover-font-family .components-popover__content {
+  min-height: 240px;
+  overflow: visible;
+  max-height: 240px; }
+
+.components-popover.kt-popover-font-family .components-popover__content {
+  padding: 10px;
+  z-index: 1; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-heading-fontfamily-title {
+    margin: 0;
+    line-height: 10px;
+    text-transform: uppercase;
+    padding-right: 0;
+    font-size: 10px;
+    margin-bottom: 4px; }
+  .components-popover.kt-popover-font-family .components-popover__content .components-base-control .components-base-control__label, .components-popover.kt-popover-font-family .components-popover__content .components-base-control .components-toggle-control__label {
+    margin-bottom: 4px;
+    font-size: 10px;
+    line-height: 10px;
+    text-transform: uppercase; }
+  .components-popover.kt-popover-font-family .components-popover__content .components-base-control .components-base-control__field {
+    margin-bottom: 0; }
+  .components-popover.kt-popover-font-family .components-popover__content .components-toggle-control .components-base-control__field .components-form-toggle {
+    display: block;
+    width: 36px;
+    margin: 6px auto 0 auto; }
+  .components-popover.kt-popover-font-family .components-popover__content .components-toggle-control .components-base-control__field {
+    margin: 0;
+    -ms-flex-direction: column-reverse;
+        flex-direction: column-reverse; }
+  .components-popover.kt-popover-font-family .components-popover__content .typography-row-settings {
+    margin-top: 10px;
+    display: -ms-flexbox;
+    display: flex; }
+    .components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .components-base-control {
+      -ms-flex: 0 1 33.33%;
+          flex: 0 1 33.33%;
+      margin-right: 5px;
+      margin-bottom: 0; }
+    .components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .components-base-control:last-child {
+      margin-right: 0px; }
+  .components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row .kt-typography__control {
+    min-height: 28px;
+    border: 1px solid #8d96a0;
+    border-radius: 4px;
+    -webkit-box-shadow: 0 0 0 transparent;
+            box-shadow: 0 0 0 transparent; }
+  .components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row .kt-typography__control--is-focused {
+    border-color: #2684ff; }
+  .components-popover.kt-popover-font-family .components-popover__content .typography-family-select-form-row .kt-typography__indicator {
+    padding: 0 8px; }
+  .components-popover.kt-popover-font-family .components-popover__content p.kt-inline-size-title {
+    font-size: 10px;
+    margin: 0;
+    line-height: 15px;
+    text-transform: uppercase; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-typography-number-input {
+    width: 70px;
+    margin-right: 0;
+    -ms-flex: none;
+        flex: none;
+    display: inline-block; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options .components-button.kt-size-btn {
+    background: transparent;
+    border: 0;
+    border-bottom: 0;
+    padding: 2px 4px;
+    margin-bottom: 0;
+    outline: 0;
+    -webkit-box-shadow: none;
+            box-shadow: none;
+    line-height: 20px;
+    height: 20px;
+    width: auto;
+    font-size: 10px; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options .components-button.kt-size-btn.is-primary {
+    color: #0085ba;
+    background: #f2f2f2;
+    -webkit-box-shadow: none;
+            box-shadow: none; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options .components-button.kt-size-btn svg {
+    width: 12px;
+    height: 12px; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-typography-size-type-options {
+    -ms-flex-positive: 2;
+        flex-grow: 2; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-size-tite-device-wrap {
+    display: -ms-flexbox;
+    display: flex;
+    text-align: right;
+    -ms-flex-align: center;
+        align-items: center; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-type-size-input-wrap .kt-typography-number-input {
+    width: 55%;
+    -ms-flex: none;
+        flex: none;
+    margin-right: 0;
+    display: inline-block; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-type-size-input-wrap .kt-typography-size-type {
+    width: 40%;
+    -ms-flex: none;
+        flex: none;
+    margin-right: 0;
+    display: inline-block; }
+  .components-popover.kt-popover-font-family .components-popover__content .kt-type-size-input-wrap {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-pack: justify;
+        justify-content: space-between; }
+
+.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-type-input-wrap {
+  -ms-flex: 0 1 33.33%;
+      flex: 0 1 33.33%;
+  margin-right: 5px;
+  margin-bottom: 0; }
+
+.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-size-input-wrap {
+  -ms-flex: 0 1 50%;
+      flex: 0 1 50%;
+  margin-right: 15px;
+  margin-bottom: 0; }
+
+.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-size-input-wrap:last-child {
+  margin-right: 0px; }
+
+.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-type-input-wrap .components-base-control {
+  -ms-flex: none;
+      flex: none;
+  display: inline-block;
+  margin-right: 0;
+  width: 70%; }
+
+.components-popover.kt-popover-font-family .components-popover__content .typography-row-settings .kt-type-input-wrap .kt-unit {
+  width: 30%;
+  display: inline-block;
+  text-align: center; }
+
+.edit-post-sidebar h2.kt-heading-size-title, .kt-block-defaults-modal h2.kt-heading-size-title {
+  font-size: 14px;
+  margin-bottom: 0;
+  color: #555d66;
+  margin-top: 30px; }
+
+.components-button-group.kt-size-type-options {
+  margin: 0;
+  text-align: right;
+  display: block;
+  margin-bottom: -18px; }
+
+.kt-size-type-options button.components-button.kt-size-btn {
+  background: transparent;
+  color: #777;
+  border: 0;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  text-shadow: none;
+  height: 18px;
+  line-height: 18px;
+  padding: 0 4px;
+  position: relative; }
+
+.kt-size-type-options button.components-button.kt-size-btn.is-primary, .kt-size-type-options button.components-button.kt-size-btn.is-primary:focus:not(:disabled):not([aria-disabled=true]) {
+  color: #000;
+  text-decoration: underline;
+  background: transparent;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  border: none;
+  outline: none; }
+
+.kt-size-type-options button.components-button.kt-size-btn:hover, .kt-size-type-options button.components-button.kt-size-btn:hover:focus:not(:disabled):not([aria-disabled=true]) {
+  color: #000;
+  background: transparent;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  border: none;
+  outline: none; }
+
+.kt-size-tabs .components-tab-panel__tabs {
+  border-bottom: 0;
+  text-align: right;
+  margin-top: -20px;
+  margin-bottom: 0; }
+
+.kt-size-tabs .components-tab-panel__tabs button {
+  background: transparent;
+  border: 0;
+  border-bottom: 0;
+  padding: 2px 4px;
+  margin-bottom: 0;
+  outline: 0;
+  width: auto;
+  font-size: 10px; }
+
+.kt-size-tabs .components-tab-panel__tabs button.active-tab {
+  color: #0085ba;
+  background: #f2f2f2; }
+
+.kt-size-tabs .components-tab-panel__tabs button svg {
+  width: 15px;
+  height: 15px; }
+
+h2.kt-heading-fontfamily-title {
+  margin: 30px 0 10px;
+  font-size: 14px;
+  color: #555d66; }
+
+button.components-button.components-icon-button.kt-font-clear-btn {
+  display: block;
+  margin-right: 0;
+  margin-left: auto;
+  margin-top: -45px;
+  text-align: center;
+  padding: 6px;
+  text-indent: 0; }
+
+.select-search-box {
+  width: auto;
+  position: relative;
+  margin-bottom: 20px;
+  background: #fff;
+  border-radius: 4px; }
+  .select-search-box::after {
+    font-family: dashicons;
+    content: "\f140";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 30px;
+    text-align: center;
+    line-height: 30px;
+    color: #222f3e;
+    z-index: 1; }
+  .select-search-box .select-search-box--input::after {
+    display: none !important; }
+  .select-search-box .select-search-box__out {
+    display: none; }
+  .select-search-box .select-search-box__search {
+    display: block;
+    width: 100%;
+    height: 30px;
+    border: none;
+    background: none;
+    outline: none;
+    font-size: 16px;
+    padding: 0 20px;
+    color: #222f3e;
+    -webkit-appearance: none;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    position: relative;
+    z-index: 2;
+    cursor: pointer;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    line-height: 30px;
+    -webkit-box-shadow: 0 7px 14px 0 rgba(50, 50, 93, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.07);
+            box-shadow: 0 7px 14px 0 rgba(50, 50, 93, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.07); }
+  .select-search-box input.select-search-box__search {
+    line-height: 1; }
+  .select-search-box .select-search-box--multiple .select-search-box__search {
+    -webkit-box-shadow: none;
+            box-shadow: none; }
+  .select-search-box .select-search-box--input .select-search-box__search {
+    cursor: text; }
+  .select-search-box .select-search-box__search:focus {
+    cursor: text; }
+  .select-search-box .select-search-box__search--placeholder {
+    font-style: italic;
+    font-weight: normal; }
+  .select-search-box .select-search-box input::-webkit-input-placeholder {
+    color: #ccc;
+    font-style: italic;
+    font-weight: normal; }
+  .select-search-box .select-search-box input::-moz-placeholder {
+    color: #ccc;
+    font-style: italic;
+    font-weight: normal; }
+  .select-search-box .select-search-box input:-moz-placeholder {
+    color: #ccc;
+    font-style: italic;
+    font-weight: normal; }
+  .select-search-box .select-search-box input:-ms-input-placeholder {
+    color: #ccc;
+    font-style: italic;
+    font-weight: normal; }
+  .select-search-box input[type='search']::-webkit-search-cancel-button, .select-search-box input[type='search']::-webkit-search-decoration {
+    -webkit-appearance: none; }
+  .select-search-box .select-search-box__select {
+    display: none;
+    position: absolute;
+    top: 35px;
+    height: 220px;
+    left: 0;
+    right: 0;
+    background: #fff;
+    border-radius: 4px;
+    overflow: auto;
+    -webkit-box-shadow: 0 7px 14px 0 rgba(50, 50, 93, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.07);
+            box-shadow: 0 7px 14px 0 rgba(50, 50, 93, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.07);
+    z-index: 100;
+    min-height: 30px; }
+  .select-search-box .select-search-box--multiple .select-search-box__select {
+    display: block;
+    position: static;
+    border-top: 1px solid #eee;
+    border-radius: 0;
+    -webkit-box-shadow: none;
+            box-shadow: none; }
+  .select-search-box .select-search-box__select--display {
+    display: block; }
+  .select-search-box .select-search-box__option {
+    font-size: 13px;
+    font-weight: 400;
+    color: #616b74;
+    line-height: 30px;
+    margin-bottom: 0;
+    padding: 0px 10px;
+    border-top: 1px solid #eee;
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    -o-text-overflow: ellipsis;
+       text-overflow: ellipsis;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none; }
+  .select-search-box .select-search-box__option:first-child {
+    border-top: none; }
+  .select-search-box .select-search-box__option--hover, .select-search-box .select-search-box__option:hover {
+    background: #f4f7fa; }
+  .select-search-box .select-search-box__option--selected {
+    background: #54A0FF;
+    color: #fff;
+    border-top-color: #2184ff; }
+  .select-search-box .select-search-box__option--selected:hover, .select-search-box .select-search-box__option--selected.select-search-box__option--hover {
+    background: #2184ff;
+    color: #fff;
+    border-top-color: #2184ff; }
+  .select-search-box .select-search-box__group {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid #eee;
+    position: relative; }
+  .select-search-box .select-search-box__group-header {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    background: white;
+    padding: 0 10px;
+    color: rgba(0, 0, 0, 0.5);
+    font-size: 12px; }
+
+.wp-block-kadence-advancedheading mark {
+  color: #f76a0c;
+  background: transparent; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.kb-device-choice.kt-size-tabs > .components-tab-panel__tabs {
+  margin-top: 0; }
+
+.kb-add-new-tab-contain {
+  text-align: right; }
+
+.kt-title-text.is-selected {
+  min-width: 5px; }
+
+.wp-block[data-type="kadence/tab"] > .block-editor-block-list__block-edit > .editor-block-mover {
+  display: none !important; }
+
+.kt-tabs-layout-vtabs .kadence-blocks-tab-item__control-menu {
+  left: auto;
+  right: 0;
+  -webkit-transform: translateX(0);
+      -ms-transform: translateX(0);
+          transform: translateX(0); }
+
+.kadence-blocks-tab-item__control-menu .components-icon-button {
+  color: white;
+  padding: 0; }
+
+.components-button.kt-tab-add.is-button.is-primary {
+  border: 0;
+  text-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  vertical-align: top;
+  padding-bottom: 2px; }
+
+.components-button.kt-tab-add.is-button.is-primary svg {
+  margin-top: 4px; }
+
+.kadence-blocks-tab-item__control-menu {
+  position: absolute;
+  top: -24px;
+  background: #0085ba;
+  padding: 2px;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+      -ms-transform: translateX(-50%);
+          transform: translateX(-50%);
+  display: none; }
+
+.block-editor-block-list__layout .kt-tabs-title-list.kb-tabs-list-columns:not(.kb-tab-title-columns-1):not(.kb-tab-title-columns-2):not(.kb-tab-title-columns-3):not(.kb-tab-title-columns-4) {
+  padding-top: 40px; }
+
+.kt-tabs-title-list.kb-tabs-list-columns:not(.kb-tab-title-columns-5):not(.kb-tab-title-columns-6):not(.kb-tab-title-columns-7):not(.kb-tab-title-columns-8):not(.kb-tab-title-columns-9):not(.kb-tab-title-columns-10) li:last-child .kadence-blocks-tab-item__control-menu {
+  left: 0;
+  -webkit-transform: translateX(0);
+      -ms-transform: translateX(0);
+          transform: translateX(0); }
+
+.kt-tabs-title-list li {
+  position: relative; }
+
+li.kt-tab-title-active .kadence-blocks-tab-item__control-menu {
+  display: -ms-flexbox;
+  display: flex; }
+
+.kt-select-starter-style-tabs {
+  padding: 20px;
+  border: 2px dashed #ddd;
+  text-align: center;
+  position: relative;
+  z-index: 10; }
+
+.kt-select-starter-style-tabs-title {
+  text-transform: uppercase;
+  padding-bottom: 10px;
+  font-size: 16px; }
+
+.kt-select-starter-style-tabs .kt-inital-tabs-style-btn {
+  height: auto;
+  width: 320px;
+  background: white;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  border: 2px solid transparent;
+  padding: 2px;
+  margin-right: 15px;
+  margin-bottom: 5px; }
+
+.kt-select-starter-style-tabs .kt-inital-tabs-style-btn svg {
+  width: 100%; }
+
+.kt-select-starter-style-tabs .kt-init-tabs-btn-group .kt-inital-tabs-style-btn:first-child {
+  width: 100%;
+  text-align: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  border: 0;
+  padding: 2px;
+  margin-right: 0;
+  margin-bottom: 5px; }
+
+.kt-select-starter-style-tabs .kt-init-tabs-btn-group .kt-inital-tabs-style-btn:first-child:hover {
+  text-decoration: underline; }
+
+.components-button-group button.components-button.kt-init-open-tab {
+  width: auto;
+  padding: 4px 10px;
+  border-radius: 3px !important;
+  height: auto;
+  text-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  margin-bottom: 5px; }
+
+.kt-select-starter-style-tabs .kt-init-tabs-btn-group .kt-inital-tabs-style-btn:first-child:focus {
+  background: transparent;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kt-select-starter-style-tabs .kt-inital-tabs-style-btn:hover {
+  border: 2px solid #aaa;
+  background: white;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+.kt-inspect-tabs .components-button-group .kt-layout-btn.kt-tablayout {
+  border-radius: 0; }
+
+.components-button-group .kt-layout-btn.kt-tablayout {
+  height: 46px; }
+  .components-button-group .kt-layout-btn.kt-tablayout svg {
+    width: 40px;
+    height: 40px; }
+  .components-button-group .kt-layout-btn.kt-tablayout:hover, .components-button-group .kt-layout-btn.kt-tablayout.is-primary, .components-button-group .kt-layout-btn.kt-tablayout:focus:not(:disabled):not([aria-disabled=true]) {
+    background: #eee;
+    border-color: #222; }
+    .components-button-group .kt-layout-btn.kt-tablayout:hover svg path, .components-button-group .kt-layout-btn.kt-tablayout:hover svg rect, .components-button-group .kt-layout-btn.kt-tablayout.is-primary svg path, .components-button-group .kt-layout-btn.kt-tablayout.is-primary svg rect, .components-button-group .kt-layout-btn.kt-tablayout:focus:not(:disabled):not([aria-disabled=true]) svg path, .components-button-group .kt-layout-btn.kt-tablayout:focus:not(:disabled):not([aria-disabled=true]) svg rect {
+      fill: #222; }
+
+.kt-tab-title .editor-rich-text {
+  display: -ms-inline-flexbox;
+  display: inline-flex; }
+
+.edit-post-sidebar p.kt-setting-label, .kt-block-defaults-modal p.kt-setting-label {
+  font-weight: 600;
+  color: #191e23;
+  padding: 0 0 5px;
+  clear: both;
+  margin-top: 0; }
+
+.kt-size-type-options.kt-outline-control .components-button.kt-size-btn {
+  padding: 2px 4px; }
+  .kt-size-type-options.kt-outline-control .components-button.kt-size-btn svg {
+    fill: #777;
+    width: 15px;
+    height: 15px; }
+  .kt-size-type-options.kt-outline-control .components-button.kt-size-btn.is-primary svg {
+    fill: #222; }
+
+.components-panel__body > .components-panel__body > .components-panel__body-title > .components-panel__body-toggle {
+  padding: 10px 10px 10px 30px; }
+
+.components-range-control.kt-icon-rangecontrol .components-base-control__label {
+  width: 30px; }
+
+.kt-inspect-tabs.kt-hover-tabs.kt-no-ho-ac-tabs .components-tab-panel__tabs button {
+  width: 33.33%;
+  padding: 6px 0;
+  font-size: 12px; }
+
+.block-editor-block-list__layout .kt-tabs-title-list {
+  padding: 0;
+  margin: 0; }
+
+.kt-tabs-title-list {
+  margin: 0;
+  padding: 0;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  list-style: none; }
+  .kt-tabs-title-list li {
+    margin: 0 4px -1px 0;
+    cursor: pointer;
+    list-style: none; }
+    .kt-tabs-title-list li .kt-tab-title {
+      padding: 8px 16px;
+      display: -ms-flexbox;
+      display: flex;
+      color: #444;
+      -ms-flex-align: center;
+          align-items: center;
+      border-style: solid;
+      border-color: transparent;
+      border-width: 1px 1px 0 1px;
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px;
+      -webkit-transition: all .2s ease-in-out;
+      -o-transition: all .2s ease-in-out;
+      transition: all .2s ease-in-out;
+      -webkit-box-shadow: none !important;
+              box-shadow: none !important;
+      outline: 0 !important; }
+    .kt-tabs-title-list li.kt-tab-title-active {
+      z-index: 4; }
+      .kt-tabs-title-list li.kt-tab-title-active .kt-tab-title {
+        background-color: #fff;
+        border-color: #dee2e6; }
+
+.kt-tabs-title-list li.kt-tabs-has-icon-false .kt-tab-title {
+  display: block; }
+
+.kt-tabs-icon-side-top .kt-tab-title {
+  -ms-flex-direction: column;
+      flex-direction: column; }
+
+.kt-tab-alignment-center > .kt-tabs-wrap > .kt-tabs-title-list {
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-tab-alignment-right > .kt-tabs-wrap > .kt-tabs-title-list {
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+.kt-tabs-content-wrap:before, .kt-tabs-content-wrap:after {
+  content: '';
+  clear: both;
+  display: table; }
+
+.kt-tabs-content-wrap {
+  border: 1px solid #dee2e6;
+  padding: 20px;
+  text-align: left;
+  position: relative; }
+
+.wp-block-kadence-tabs .editor-block-list__layout .editor-block-list__block {
+  max-width: none !important; }
+
+.kt-tabs-content-wrap [data-type="kadence/tab"] {
+  display: none; }
+
+.wp-block-kadence-tabs.kt-active-tab-1 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="1"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-2 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="2"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-3 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="3"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-4 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="4"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-5 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="5"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-6 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="6"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-7 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="7"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-8 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="8"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-9 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="9"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-10 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="10"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-11 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="11"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-12 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="12"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-13 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="13"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-14 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="14"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-15 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="15"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-16 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="16"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-17 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="17"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-18 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="18"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-19 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="19"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-20 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="20"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-21 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="21"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-22 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="22"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-23 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="23"] {
+  display: block; }
+
+.wp-block-kadence-tabs.kt-active-tab-24 > .kt-tabs-wrap > .kt-tabs-content-wrap > .editor-inner-blocks > .editor-block-list__layout > [data-tab="24"] {
+  display: block; }
+
+.kt-tabs-layout-vtabs:after, .kt-tabs-wrap:after {
+  clear: both;
+  display: table;
+  content: ''; }
+
+.kt-tabs-layout-vtabs > .kt-tabs-wrap > .kt-tabs-title-list {
+  float: left;
+  width: 30%;
+  -ms-flex-direction: column;
+      flex-direction: column; }
+  .kt-tabs-layout-vtabs > .kt-tabs-wrap > .kt-tabs-title-list li {
+    margin: 0 -1px 4px 0; }
+    .kt-tabs-layout-vtabs > .kt-tabs-wrap > .kt-tabs-title-list li .kt-tab-title {
+      border-width: 1px 0px 1px 1px;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0; }
+
+.kt-tabs-layout-vtabs > .kt-tabs-wrap > .kt-tabs-content-wrap {
+  float: left;
+  width: 70%; }
+
+.kt-tabs-layout-vtabs.kt-tab-alignment-left > .kt-tabs-wrap > .kt-tabs-title-list li .kt-tab-title {
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+
+.kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-wrap > .kt-tabs-title-list {
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+  .kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-wrap > .kt-tabs-title-list li {
+    text-align: center; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-wrap > .kt-tabs-title-list li .kt-tab-title {
+      -ms-flex-pack: center;
+          justify-content: center; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-wrap > .kt-tabs-title-list li .kb-tab-titles-wrap {
+      -ms-flex-align: center;
+          align-items: center; }
+
+.kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-wrap > .kt-tabs-title-list {
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+  .kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-wrap > .kt-tabs-title-list li {
+    text-align: right; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-wrap > .kt-tabs-title-list li .kt-tab-title {
+      -ms-flex-pack: end;
+          justify-content: flex-end;
+      -ms-flex-align: center;
+          align-items: center; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-wrap > .kt-tabs-title-list li .kb-tab-titles-wrap {
+      -ms-flex-align: end;
+          align-items: flex-end; }
+
+.kt-tabs-svg-show-only .editor-rich-text {
+  display: none; }
+
+.kt-title-svg-side-left {
+  padding-right: 5px; }
+
+.kt-title-svg-side-right {
+  padding-left: 5px; }
+
+.kt-tabs-svg-show-only .kt-title-svg-side-right {
+  padding-left: 0px; }
+
+.kt-tabs-svg-show-only .kt-title-svg-side-left {
+  padding-right: 0px; }
+
+.kt-tabs-wrap {
+  margin: 0 auto; }
+
+.kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-wrap > .kt-tabs-title-list li .kb-tab-titles-wrap {
+  -ms-flex-align: center;
+      align-items: center; }
+
+.kb-tab-titles-wrap {
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -ms-flex-direction: column;
+      flex-direction: column; }
+
+.kt-title-sub-text {
+  font-size: 14px;
+  line-height: 24px; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-8 > li {
+  -ms-flex: 0 1 12.5%;
+      flex: 0 1 12.5%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-7 > li {
+  -ms-flex: 0 1 14.28%;
+      flex: 0 1 14.28%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-6 > li {
+  -ms-flex: 0 1 16.67%;
+      flex: 0 1 16.67%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-5 > li {
+  -ms-flex: 0 1 20%;
+      flex: 0 1 20%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-4 > li {
+  -ms-flex: 0 1 25%;
+      flex: 0 1 25%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-3 > li {
+  -ms-flex: 0 1 33.33%;
+      flex: 0 1 33.33%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-2 > li {
+  -ms-flex: 0 1 50%;
+      flex: 0 1 50%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-1 > li {
+  -ms-flex: 0 1 100%;
+      flex: 0 1 100%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-1 > li > .kt-tab-title {
+  margin-right: 0px !important; }
+
+ul.kt-tabs-title-list.kb-tabs-list-columns > li:last-child > .kt-tab-title {
+  margin-right: 0px !important; }
+
+ul.kt-tabs-title-list.kb-tabs-list-columns .kt-tab-title {
+  -ms-flex-pack: center;
+      justify-content: center;
+  text-align: center; }
+
+.kt-tab-alignment-center ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap {
+  -ms-flex-align: center;
+      align-items: center; }
+
+.kt-tab-alignment-right ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap {
+  -ms-flex-align: end;
+      align-items: flex-end; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.kb-upload-inline-btn.kt-cta-upload-btn {
+  margin-bottom: 0; }
+
+.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media .editor-media-placeholder {
+  padding: 1em;
+  margin: 0; }
+
+.edit-post-sidebar .kb-image-size-select-form-row input[type=text], .kt-block-defaults-modal .kb-image-size-select-form-row input[type=text] {
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kb-image-size-container .kb-image-size-select-form-row {
+  margin-bottom: 10px;
+  z-index: 200;
+  position: relative; }
+
+.kb-image-size-container .kb-image-size-title {
+  font-weight: normal;
+  margin-bottom: 4px; }
+
+.kb-image-edit-settings-container {
+  display: -ms-flexbox;
+  display: flex;
+  margin-bottom: 10px; }
+
+.kadence-info-box-image-intrisic {
+  height: 0; }
+
+.kt-infobox-textcontent .kt-blocks-info-box-text {
+  margin-top: 0; }
+
+.kt-controls-link-wrap .editor-url-input input[type=text] {
+  width: 100%; }
+
+.edit-post-sidebar .kt-controls-link-wrap h2 {
+  margin-top: 0; }
+
+.kt-select-starter-style-tabs.kt-select-starter-style-infobox .kt-inital-tabs-style-btn {
+  width: 120px; }
+
+.kt-info-halign-center {
+  text-align: center; }
+  .kt-info-halign-center .kadence-info-box-image-inner-intrisic-container {
+    margin: 0 auto; }
+
+.kt-info-halign-right {
+  text-align: right; }
+  .kt-info-halign-right .kadence-info-box-image-inner-intrisic-container {
+    margin: 0 0 0 auto; }
+
+.kt-info-halign-left {
+  text-align: left; }
+  .kt-info-halign-left .kadence-info-box-image-inner-intrisic-container {
+    margin: 0 auto 0 0; }
+
+.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media {
+  display: inline-block; }
+
+.kt-blocks-info-box-media-align-top .kt-infobox-textcontent {
+  display: block; }
+
+.wp-block-kadence-infobox .kt-blocks-info-box-text {
+  margin-bottom: 0; }
+
+.kt-blocks-info-box-media, .kt-blocks-info-box-link-wrap {
+  border: 0 solid transparent;
+  -webkit-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  -o-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95); }
+
+.kt-blocks-info-box-title, .kt-blocks-info-box-text, .kt-blocks-info-box-learnmore {
+  -webkit-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  -o-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95); }
+
+.kt-blocks-info-box-learnmore {
+  border: 0 solid transparent; }
+
+.kt-blocks-info-box-text {
+  color: #555555; }
+
+.wp-block-kadence-infobox .kt-blocks-info-box-learnmore-wrap {
+  display: inline-block;
+  width: auto; }
+
+.kt-blocks-info-box-media-align-left {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+
+.kt-blocks-info-box-media-align-right {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: start;
+      justify-content: flex-start;
+  -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse; }
+
+.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-top, .kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-top {
+  -ms-flex-align: start;
+      align-items: flex-start; }
+
+.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-bottom, .kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-bottom {
+  -ms-flex-align: end;
+      align-items: flex-end; }
+
+.kadence-info-box-image-intrisic.kb-info-box-image-type-svg {
+  height: auto;
+  padding-bottom: 0; }
+
+.kt-info-animate-grayscale img, .kt-info-animate-grayscale-border-draw img {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  -webkit-transition: 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  -o-transition: 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  transition: 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95); }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale img, .kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale-border-draw img {
+  -webkit-filter: grayscale(0);
+  filter: grayscale(0); }
+
+.kt-info-animate-flip, .kt-info-icon-animate-flip {
+  -webkit-perspective: 1000;
+          perspective: 1000; }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-animate-flip .kadence-info-box-image-inner-intrisic, .kt-blocks-info-box-link-wrap:hover .kt-info-icon-animate-flip .kadence-info-box-icon-inner-container {
+  -webkit-transform: rotateY(180deg);
+          transform: rotateY(180deg); }
+
+.kt-info-animate-flip .kadence-info-box-image-inner-intrisic, .kt-info-icon-animate-flip .kadence-info-box-icon-inner-container {
+  -webkit-transition: 0.6s;
+  -o-transition: 0.6s;
+  transition: 0.6s;
+  -webkit-transform-style: preserve-3d;
+          transform-style: preserve-3d;
+  position: relative; }
+
+.kt-info-animate-flip .kt-info-box-image-flip, .kt-info-icon-animate-flip .kt-info-svg-icon-flip {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
+  position: absolute;
+  top: 0;
+  left: 0; }
+
+.kt-info-animate-flip .kt-info-box-image, .kt-info-icon-animate-flip .kt-info-svg-icon {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.kt-info-animate-flip .kt-info-box-image, .kt-info-icon-animate-flip .kt-info-svg-icon {
+  z-index: 2; }
+
+.kt-info-animate-flip .kt-info-box-image-flip, .kt-info-icon-animate-flip .kt-info-svg-icon-flip {
+  -webkit-transform: rotateY(180deg);
+          transform: rotateY(180deg); }
+
+.kt-info-media-animate-drawborder, .kt-info-media-animate-grayscale-border-draw {
+  position: relative;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+  .kt-info-media-animate-drawborder::before, .kt-info-media-animate-drawborder::after, .kt-info-media-animate-grayscale-border-draw::before, .kt-info-media-animate-grayscale-border-draw::after {
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    content: '';
+    position: absolute;
+    border: 0px solid transparent;
+    width: 0;
+    height: 0; }
+  .kt-info-media-animate-drawborder::before, .kt-info-media-animate-drawborder::after, .kt-info-media-animate-grayscale-border-draw::before, .kt-info-media-animate-grayscale-border-draw::after {
+    top: 0;
+    left: 0; }
+  .kt-info-media-animate-drawborder:after, .kt-info-media-animate-grayscale-border-draw:after {
+    -webkit-transform: rotate(-90deg);
+        -ms-transform: rotate(-90deg);
+            transform: rotate(-90deg); }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:before, .kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:before {
+  width: 100%;
+  height: 100%;
+  -webkit-transition: border-top-color 0.15s linear, border-right-color 0.15s linear 0.1s, border-bottom-color 0.15s linear 0.2s;
+  -o-transition: border-top-color 0.15s linear, border-right-color 0.15s linear 0.1s, border-bottom-color 0.15s linear 0.2s;
+  transition: border-top-color 0.15s linear, border-right-color 0.15s linear 0.1s, border-bottom-color 0.15s linear 0.2s; }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:after, .kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:after {
+  width: 100%;
+  height: 100%;
+  -webkit-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg);
+  -webkit-transition: border-bottom-width 0s linear 0.35s, -webkit-transform 0.4s linear 0s;
+  transition: border-bottom-width 0s linear 0.35s, -webkit-transform 0.4s linear 0s;
+  -o-transition: transform 0.4s linear 0s, border-bottom-width 0s linear 0.35s;
+  transition: transform 0.4s linear 0s, border-bottom-width 0s linear 0.35s;
+  transition: transform 0.4s linear 0s, border-bottom-width 0s linear 0.35s, -webkit-transform 0.4s linear 0s; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.kt-border-color-array-control .components-color-palette {
+  padding-left: 50px; }
+
+.kt-border-color-array-control .kt-border-color-icon {
+  float: left;
+  width: 40px;
+  height: 40px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  background: #f9f9f9;
+  margin-right: 10px; }
+
+.rfipbtn.rfipbtn--accordion {
+  background-color: #fff;
+  border: 1px solid #e0e0e0;
+  width: 96%; }
+  .rfipbtn.rfipbtn--accordion:active, .rfipbtn.rfipbtn--accordion:focus {
+    border: 1px solid #bdbdbd; }
+  .rfipbtn.rfipbtn--accordion .rfipbtn__current {
+    -ms-flex: 100%;
+        flex: 100%;
+    -ms-flex-pack: start;
+        justify-content: flex-start;
+    padding: 0; }
+    .rfipbtn.rfipbtn--accordion .rfipbtn__current svg.top-icon {
+      -webkit-transform: rotate(180deg) !important;
+          -ms-transform: rotate(180deg) !important;
+              transform: rotate(180deg) !important; }
+    .rfipbtn.rfipbtn--accordion .rfipbtn__current .rfipbtn__icon {
+      width: 100%; }
+      .rfipbtn.rfipbtn--accordion .rfipbtn__current .rfipbtn__icon .rfipbtn__elm {
+        width: 100%; }
+        .rfipbtn.rfipbtn--accordion .rfipbtn__current .rfipbtn__icon .rfipbtn__elm svg {
+          width: auto; }
+  .rfipbtn.rfipbtn--accordion .rfipbtn__button {
+    border: 0 none transparent;
+    border-left: 1px solid #e0e0e0;
+    background-color: #f5f5f5;
+    color: #424242; }
+    .rfipbtn.rfipbtn--accordion .rfipbtn__button:hover {
+      background-color: #bdbdbd; }
+    .rfipbtn.rfipbtn--accordion .rfipbtn__button:active {
+      -webkit-box-shadow: inset 0 0 10px 0 #e0e0e0;
+              box-shadow: inset 0 0 10px 0 #e0e0e0; }
+  .rfipbtn.rfipbtn--accordion .rfipbtn__icon {
+    border: 0;
+    color: #424242; }
+    .rfipbtn.rfipbtn--accordion .rfipbtn__icon--empty {
+      color: #555d66;
+      text-transform: none;
+      text-align: left; }
+  .rfipbtn.rfipbtn--accordion .rfipbtn__del {
+    background-color: #eee; }
+    .rfipbtn.rfipbtn--accordion .rfipbtn__del:hover {
+      background-color: #e0e0e0; }
+    .rfipbtn.rfipbtn--accordion .rfipbtn__del:focus, .rfipbtn.rfipbtn--accordion .rfipbtn__del:active {
+      outline: 1px solid #e0e0e0; }
+
+.rfipdropdown.rfipdropdown--accordion {
+  max-height: 240px;
+  overflow: scroll; }
+
+.rfipdropdown.rfipdropdown--accordion {
+  background-color: #fff;
+  border: 1px solid #e0e0e0; }
+  .rfipdropdown.rfipdropdown--accordion .rfipdropdown__selector {
+    overflow: hidden;
+    padding: 8px; }
+  .rfipdropdown.rfipdropdown--accordion .rfipicons__pager {
+    display: none; }
+  .rfipdropdown.rfipdropdown--accordion .rfipicons__cp {
+    border-bottom: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__cp:focus {
+      border-bottom-color: #9e9e9e; }
+  .rfipdropdown.rfipdropdown--accordion .rfipicons__left, .rfipdropdown.rfipdropdown--accordion .rfipicons__right {
+    background-color: #eee;
+    border: 1px solid #eee;
+    color: #424242; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__left:hover, .rfipdropdown.rfipdropdown--accordion .rfipicons__right:hover {
+      background-color: #bdbdbd;
+      border: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__left:focus, .rfipdropdown.rfipdropdown--accordion .rfipicons__left:active, .rfipdropdown.rfipdropdown--accordion .rfipicons__right:focus, .rfipdropdown.rfipdropdown--accordion .rfipicons__right:active {
+      border: 1px solid #bdbdbd; }
+  .rfipdropdown.rfipdropdown--accordion .rfipicons__ibox {
+    background-color: #f5f5f5;
+    border: 1px solid #f5f5f5;
+    color: #424242; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__ibox:hover {
+      background-color: #bdbdbd;
+      border: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__ibox:focus, .rfipdropdown.rfipdropdown--accordion .rfipicons__ibox:active {
+      border: 1px solid #bdbdbd; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__ibox--error {
+      color: red; }
+  .rfipdropdown.rfipdropdown--accordion .rfipicons__icon {
+    width: 100%;
+    height: 50px;
+    margin: 2px 0; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__icon svg {
+      fill: #000;
+      width: 100px;
+      -webkit-transform: scale(1);
+          -ms-transform: scale(1);
+              transform: scale(1); }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__icon svg.top-icon {
+      -webkit-transform: rotate(180deg) !important;
+          -ms-transform: rotate(180deg) !important;
+              transform: rotate(180deg) !important; }
+    .rfipdropdown.rfipdropdown--accordion .rfipicons__icon--selected .rfipicons__ibox {
+      background-color: #eee; }
+
+.kt-accordion-selecter {
+  border: 2px dashed #aaa;
+  font-size: 12px;
+  text-align: center;
+  cursor: pointer;
+  text-transform: uppercase;
+  font-weight: bold;
+  color: #999; }
+
+.kt-accordion-wrap .kt-accordion-header-wrap {
+  margin: 0;
+  padding: 0; }
+
+.kt-blocks-accordion-header {
+  -ms-flex-line-pack: justify;
+      align-content: space-between;
+  -ms-flex-align: center;
+      align-items: center;
+  background-color: #f2f2f2;
+  border: 0 solid transparent;
+  border-radius: 0px;
+  color: #444444;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 8px 12px;
+  text-align: left;
+  -webkit-transition: all ease-in-out .2s;
+  -o-transition: all ease-in-out .2s;
+  transition: all ease-in-out .2s;
+  width: 100%; }
+
+.kt-accordion-panel-inner {
+  padding: 20px;
+  border: 1px solid #eee;
+  border-top-width: 0; }
+
+.kt-accordion-add-selecter {
+  display: -ms-flexbox;
+  display: flex; }
+
+button.components-button.kt-accordion-add.is-button.is-primary {
+  border: 0;
+  text-shadow: none;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kt-accordion-add-selecter button.components-button.kt-accordion-remove {
+  border: 0;
+  text-shadow: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  background: #e1e1e1;
+  border-radius: 3px;
+  margin-left: 5px;
+  height: 28px;
+  line-height: 26px;
+  padding: 0 10px 1px; }
+
+.kt-accordion-add-selecter button.components-button.kt-accordion-remove:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
+  background: #eee;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+button.components-button.kt-accordion-add.is-button.is-primary svg {
+  margin-top: 4px; }
+
+.components-button-group button.components-button.kt-init-open-pane {
+  width: 100%;
+  padding: 4px 10px;
+  border-radius: 3px !important;
+  height: auto;
+  text-shadow: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  margin-bottom: 5px; }
+
+.components-button-group button.components-button.kt-init-open-pane:focus:enabled {
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kt-blocks-accordion-icon-trigger {
+  display: block;
+  height: 24px;
+  margin-left: auto;
+  position: relative;
+  -webkit-transition: all ease-in-out 0.2s;
+  -o-transition: all ease-in-out 0.2s;
+  transition: all ease-in-out 0.2s;
+  width: 24px;
+  min-width: 24px;
+  -webkit-box-sizing: content-box;
+          box-sizing: content-box; }
+
+.kt-blocks-accordion-title-wrap {
+  display: -ms-flexbox;
+  display: flex; }
+
+.kt-pane-header-alignment-center .kt-blocks-accordion-header {
+  text-align: center; }
+
+.kt-pane-header-alignment-center .kt-blocks-accordion-header .kt-blocks-accordion-title-wrap {
+  -ms-flex-positive: 2;
+      flex-grow: 2;
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-pane-header-alignment-right .kt-blocks-accordion-header {
+  text-align: right; }
+
+.kt-pane-header-alignment-right .kt-blocks-accordion-header .kt-blocks-accordion-title-wrap {
+  -ms-flex-positive: 2;
+      flex-grow: 2;
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+.kt-pane-header-alignment-right .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger {
+  margin-left: 10px; }
+
+.kt-acccordion-button-label-hide .editor-rich-text {
+  display: none; }
+
+.kt-accodion-icon-style-none .kt-blocks-accordion-icon-trigger {
+  display: none; }
+
+.kt-accodion-icon-side-left .kt-blocks-accordion-icon-trigger {
+  -ms-flex-order: -1;
+      order: -1;
+  margin-left: 0;
+  margin-right: 10px; }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before {
+  content: "";
+  height: 4px;
+  position: absolute;
+  -webkit-transition: all ease-in-out 0.1333333333s;
+  -o-transition: all ease-in-out 0.1333333333s;
+  transition: all ease-in-out 0.1333333333s;
+  width: 20px;
+  left: 2px;
+  top: 10px; }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-2.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-3.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-4.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-5.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-6.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-7.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-8.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-9.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-10.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-2.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-3.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-4.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-5.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-6.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-7.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-8.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-9.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-10.kt-accodion-icon-style-basic > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger {
+  border-radius: 50%; }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before {
+  width: 16px;
+  left: 4px;
+  top: 10px; }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-2.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-3.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-4.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-5.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-6.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-7.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-8.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-9.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-10.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-2.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-3.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-4.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-5.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-6.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-7.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-8.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-9.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-10.kt-accodion-icon-style-basiccircle > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg); }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg); }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before {
+  content: "";
+  height: 4px;
+  position: absolute;
+  -webkit-transition: all ease-in-out 0.1333333333s;
+  -o-transition: all ease-in-out 0.1333333333s;
+  transition: all ease-in-out 0.1333333333s;
+  width: 20px;
+  left: 2px;
+  top: 10px; }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-2.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-3.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-4.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-5.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-6.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-7.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-8.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-9.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-10.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg); }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-2.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-3.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-4.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-5.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-6.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-7.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-8.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-9.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-10.kt-accodion-icon-style-xclose > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg); }
+
+.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger {
+  border-radius: 50%; }
+
+.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before {
+  width: 16px;
+  left: 4px;
+  top: 10px; }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-2.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-3.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-4.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-5.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-6.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-7.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-8.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-9.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-10.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg); }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-2.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-3.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-4.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-5.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-6.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-7.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-8.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-9.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-10.kt-accodion-icon-style-xclosecircle > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg); }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  content: "";
+  height: 2px;
+  position: absolute;
+  top: 11px;
+  -webkit-transition: all ease-in-out 0.1333333333s;
+  -o-transition: all ease-in-out 0.1333333333s;
+  transition: all ease-in-out 0.1333333333s;
+  width: 12px; }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  left: 2px;
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg);
+  right: 2px;
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-2.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-3.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-4.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-5.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-6.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-7.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-8.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-9.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-10.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg); }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-2.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-3.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-4.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-5.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-6.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-7.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-8.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-9.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-10.kt-accodion-icon-style-arrow > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg); }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger {
+  border-radius: 50%; }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  width: 10px; }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  left: 4px; }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after {
+  right: 4px; }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-2.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-3.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-4.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-5.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-6.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-7.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-8.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-9.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-start-active-pane-10.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg); }
+
+.kt-start-active-pane-1.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-1 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-2.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-2 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-3.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-3 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-4.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-4 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-5.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-5 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-6.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-6 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-7.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-7 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-8.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-8 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-9.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-9 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after, .kt-start-active-pane-10.kt-accodion-icon-style-arrowcircle > div > div > div > div > div > .kt-accordion-pane-10 > div > .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg); }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.kadence-blocks-list-item__control-menu {
+  display: -ms-flexbox;
+  display: flex; }
+
+.kt-btn-size-settings-container .components-button-group .components-button.is-button.is-primary svg {
+  fill: white; }
+
+.kt-svg-icon-list-item-wrap {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  text-align: left; }
+
+.kt-svg-icon-list-single {
+  margin-right: 10px;
+  padding: 4px 0; }
+
+.kt-svg-icon-list-item-wrap .editor-rich-text {
+  -ms-flex-positive: 2;
+      flex-grow: 2; }
+
+.block-editor-block-list__block[data-align=center] .kt-svg-icon-list-item-wrap {
+  -ms-flex-pack: center;
+      justify-content: center; }
+  .block-editor-block-list__block[data-align=center] .kt-svg-icon-list-item-wrap .editor-rich-text {
+    min-width: 20px;
+    -ms-flex-positive: 0;
+        flex-grow: 0; }
+
+.kt-svg-icon-list-style-stacked .kt-svg-icon-list-single {
+  border: 0px solid transparent; }
+
+.kt-svg-icon-list-columns-2 {
+  grid-template-columns: 50% auto;
+  grid-template-rows: auto;
+  display: grid; }
+
+.kt-svg-icon-list-columns-3 {
+  grid-template-columns: 33% 33% auto;
+  grid-template-rows: auto;
+  display: grid; }
+
+.kt-list-icon-aligntop .kt-svg-icon-list-item-wrap {
+  -ms-flex-align: start;
+      align-items: flex-start; }
+
+.kt-list-icon-alignbottom .kt-svg-icon-list-item-wrap {
+  -ms-flex-align: end;
+      align-items: flex-end; }
+@charset "UTF-8";
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+/* Slider */
+.kt-blocks-carousel {
+  padding: 0 0 25px 0;
+  /* Arrows */
+  /* Dots */ }
+  .kt-blocks-carousel .slick-slider {
+    position: relative;
+    display: block;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    -ms-touch-action: pan-y;
+    touch-action: pan-y;
+    -webkit-tap-highlight-color: transparent; }
+  .kt-blocks-carousel .slick-list {
+    position: relative;
+    overflow: hidden;
+    display: block;
+    margin: 0;
+    padding: 0; }
+    .kt-blocks-carousel .slick-list:focus {
+      outline: none; }
+    .kt-blocks-carousel .slick-list.dragging {
+      cursor: pointer;
+      cursor: hand; }
+  .kt-blocks-carousel .slick-slider .slick-track,
+  .kt-blocks-carousel .slick-slider .slick-list {
+    -webkit-transform: translate3d(0, 0, 0);
+            transform: translate3d(0, 0, 0); }
+  .kt-blocks-carousel .slick-track {
+    position: relative;
+    left: 0;
+    top: 0;
+    display: block;
+    margin-left: auto;
+    margin-right: auto; }
+    .kt-blocks-carousel .slick-track:before, .kt-blocks-carousel .slick-track:after {
+      content: "";
+      display: table; }
+    .kt-blocks-carousel .slick-track:after {
+      clear: both; }
+  .kt-blocks-carousel .slick-loading .slick-track {
+    visibility: hidden; }
+  .kt-blocks-carousel .slick-slide {
+    float: left;
+    height: 100%;
+    min-height: 1px;
+    display: none; }
+    [dir="rtl"] .kt-blocks-carousel .slick-slide {
+      float: right; }
+    .kt-blocks-carousel .slick-slide img {
+      display: block; }
+    .kt-blocks-carousel .slick-slide.slick-loading img {
+      display: none; }
+    .kt-blocks-carousel .slick-slide.dragging img {
+      pointer-events: none; }
+  .kt-blocks-carousel .slick-initialized .slick-slide {
+    display: block; }
+  .kt-blocks-carousel .slick-loading .slick-slide {
+    visibility: hidden; }
+  .kt-blocks-carousel .slick-vertical .slick-slide {
+    display: block;
+    height: auto;
+    border: 1px solid transparent; }
+  .kt-blocks-carousel .slick-arrow.slick-hidden {
+    display: none; }
+  .kt-blocks-carousel .slick-slider:hover .slick-prev,
+  .kt-blocks-carousel .slick-slider:hover .slick-next {
+    opacity: 0.75; }
+    .kt-blocks-carousel .slick-slider:hover .slick-prev:hover, .kt-blocks-carousel .slick-slider:hover .slick-prev:focus,
+    .kt-blocks-carousel .slick-slider:hover .slick-next:hover,
+    .kt-blocks-carousel .slick-slider:hover .slick-next:focus {
+      outline: none;
+      opacity: 1; }
+    .kt-blocks-carousel .slick-slider:hover .slick-prev.slick-disabled,
+    .kt-blocks-carousel .slick-slider:hover .slick-next.slick-disabled {
+      opacity: 0.25; }
+  .kt-blocks-carousel .slick-prev,
+  .kt-blocks-carousel .slick-next {
+    position: absolute;
+    display: block;
+    height: 50px;
+    width: 30px;
+    line-height: 0px;
+    font-size: 0px;
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    top: 50%;
+    -webkit-transform: translate(0, -50%);
+        -ms-transform: translate(0, -50%);
+            transform: translate(0, -50%);
+    padding: 0;
+    border: none;
+    outline: none;
+    opacity: 0.25;
+    z-index: 1; }
+    .kt-blocks-carousel .slick-prev:hover, .kt-blocks-carousel .slick-prev:focus,
+    .kt-blocks-carousel .slick-next:hover,
+    .kt-blocks-carousel .slick-next:focus {
+      outline: none;
+      opacity: 1; }
+    .kt-blocks-carousel .slick-prev.slick-disabled,
+    .kt-blocks-carousel .slick-next.slick-disabled {
+      opacity: 0; }
+  .kt-blocks-carousel [dir="rtl"] .slick-prev {
+    left: auto;
+    right: 0px;
+    -webkit-transform: translate(0, -50%) rotate(180deg);
+        -ms-transform: translate(0, -50%) rotate(180deg);
+            transform: translate(0, -50%) rotate(180deg); }
+  .kt-blocks-carousel .slick-prev {
+    left: 0px; }
+  .kt-blocks-carousel [dir="rtl"] .slick-next {
+    left: -25px;
+    right: auto;
+    -webkit-transform: translate(0, -50%) rotate(180deg);
+        -ms-transform: translate(0, -50%) rotate(180deg);
+            transform: translate(0, -50%) rotate(180deg); }
+  .kt-blocks-carousel .slick-next {
+    right: 0px; }
+  .kt-blocks-carousel .kt-carousel-arrowstyle-blackonlight .slick-prev,
+  .kt-blocks-carousel .kt-carousel-arrowstyle-blackonlight .slick-next {
+    background: rgba(255, 255, 255, 0.8);
+    color: black; }
+  .kt-blocks-carousel .kt-carousel-arrowstyle-outlineblack .slick-prev,
+  .kt-blocks-carousel .kt-carousel-arrowstyle-outlineblack .slick-next {
+    background: transparent;
+    border: 2px solid #000000;
+    color: black; }
+  .kt-blocks-carousel .kt-carousel-arrowstyle-outlinewhite .slick-prev,
+  .kt-blocks-carousel .kt-carousel-arrowstyle-outlinewhite .slick-next {
+    background: transparent;
+    border: 2px solid #ffffff;
+    color: #ffffff; }
+  .kt-blocks-carousel .slick-dotted.slick-slider {
+    margin-bottom: 30px; }
+  .kt-blocks-carousel .slick-dots {
+    position: absolute;
+    bottom: -25px;
+    list-style: none;
+    display: block;
+    text-align: center;
+    padding: 0 0 5px 0;
+    margin: 0;
+    left: 0;
+    width: 100%; }
+    .kt-blocks-carousel .slick-dots li {
+      position: relative;
+      display: inline-block;
+      height: 20px;
+      width: 20px;
+      margin: 0;
+      padding: 0;
+      cursor: pointer; }
+      .kt-blocks-carousel .slick-dots li button {
+        border: 0;
+        background: transparent;
+        display: block;
+        height: 20px;
+        width: 20px;
+        outline: none;
+        line-height: 0px;
+        font-size: 0px;
+        color: transparent;
+        padding: 5px;
+        cursor: pointer; }
+        .kt-blocks-carousel .slick-dots li button:hover, .kt-blocks-carousel .slick-dots li button:focus {
+          outline: none; }
+          .kt-blocks-carousel .slick-dots li button:hover:before, .kt-blocks-carousel .slick-dots li button:focus:before {
+            opacity: 1; }
+        .kt-blocks-carousel .slick-dots li button:before {
+          position: absolute;
+          top: 0;
+          left: 0;
+          content: "•";
+          width: 20px;
+          height: 20px;
+          font-size: 30px;
+          line-height: 20px;
+          text-align: center;
+          color: black;
+          opacity: 0.25;
+          -webkit-font-smoothing: antialiased;
+          -moz-osx-font-smoothing: grayscale; }
+      .kt-blocks-carousel .slick-dots li.slick-active button:before {
+        color: black;
+        opacity: 0.75; }
+  .kt-blocks-carousel .kt-carousel-dotstyle-light .slick-dots li button:before {
+    color: white; }
+  .kt-blocks-carousel .kt-carousel-dotstyle-light .slick-dots li.slick-active button:before {
+    color: white; }
+  .kt-blocks-carousel .kt-carousel-dotstyle-outlinedark .slick-dots li button:before {
+    content: "\25CB";
+    font-size: 21px;
+    line-height: 18px; }
+  .kt-blocks-carousel .kt-carousel-dotstyle-outlinedark .slick-dots li.slick-active button:before {
+    content: "•";
+    font-size: 30px;
+    line-height: 20px; }
+  .kt-blocks-carousel .kt-carousel-dotstyle-outlinelight .slick-dots li button:before {
+    content: "\25CB";
+    color: white;
+    font-size: 21px;
+    line-height: 18px; }
+  .kt-blocks-carousel .kt-carousel-dotstyle-outlinelight .slick-dots li.slick-active button:before {
+    color: white;
+    content: "•";
+    font-size: 30px;
+    line-height: 20px; }
+
+.wp-block-kadence-testimonials .kt-blocks-carousel {
+  padding-bottom: 35px; }
+
+.wp-block-kadence-testimonials .kt-blocks-carousel.kt-carousel-container-dotstyle-none {
+  padding-bottom: 0; }
+
+.wp-block-kadence-testimonials .kt-blocks-carousel .slick-slider:not(.kt-carousel-arrowstyle-none) {
+  padding-left: 35px;
+  padding-right: 35px; }
+
+.kt-spacer-sidebar-15 {
+  height: 15px; }
+
+.kt-testimonial-item__move-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 0; }
+
+.kt-testimonial-item-wrap:hover .kt-testimonial-item__move-menu {
+  display: -ms-inline-flexbox;
+  display: inline-flex; }
+
+.kt-testimonial-item__move-menu .components-button {
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.8); }
+  .kt-testimonial-item__move-menu .components-button:focus:enabled {
+    border-color: transparent;
+    outline: 0;
+    outline-offset: 0;
+    -webkit-box-shadow: none;
+            box-shadow: none;
+    color: #555d66; }
+
+.components-button-group.kt-style-btn-group button.components-button.kt-style-btn {
+  width: 50%;
+  border: 0;
+  height: auto;
+  border-radius: 0;
+  background: transparent;
+  padding: 8px;
+  border: 2px solid transparent;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.components-button-group button.components-button.kt-style-btn svg {
+  width: 100%; }
+
+.kt-style-btn-group {
+  margin-bottom: 10px; }
+
+.components-button-group .components-button.is-button.is-primary.kt-style-btn, .components-button-group .components-button.kt-style-btn.is-button:focus {
+  border-color: #aaaaaa;
+  background: transparent;
+  outline: 0;
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.components-button-group button.components-button.kt-style-btn:hover {
+  border-color: #eeeeee; }
+
+.kt-testimonial-grid-wrap {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
+  grid-gap: 30px 30px; }
+
+.kt-testimonial-columns-1 .kt-testimonial-grid-wrap {
+  display: block; }
+
+.kt-testimonial-columns-3 .kt-testimonial-grid-wrap {
+  grid-template-columns: 1fr 1fr 1fr; }
+
+.kt-testimonial-columns-4 .kt-testimonial-grid-wrap {
+  grid-template-columns: 1fr 1fr 1fr 1fr; }
+
+.kt-testimonial-columns-5 .kt-testimonial-grid-wrap {
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap {
+  width: 100%; }
+
+.kt-testimonial-media-inner-wrap {
+  overflow: hidden;
+  border: 0 solid transparent;
+  width: 60px;
+  margin: 0 15px 0 0;
+  border-radius: 100%; }
+  .kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic {
+    padding-bottom: 100%;
+    height: 0;
+    position: relative; }
+  .kt-testimonial-media-inner-wrap .kt-testimonial-image {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    padding: 0;
+    border-radius: 100%; }
+  .kt-testimonial-media-inner-wrap .kt-testimonial-image-placeholder {
+    background: #f2f2f2;
+    width: 100%;
+    height: 100%;
+    border-radius: 100%;
+    -ms-flex-pack: center;
+        justify-content: center;
+    position: absolute; }
+  .kt-testimonial-media-inner-wrap .kt-svg-testimonial-icon {
+    position: absolute;
+    width: 100%;
+    height: 100%; }
+
+.kt-testimonial-item-wrap {
+  border: 0 solid transparent;
+  max-width: 500px;
+  text-align: center;
+  margin: 0 auto;
+  position: relative; }
+
+.kt-testimonial-meta-wrap {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: center;
+      justify-content: center;
+  -ms-flex-align: center;
+      align-items: center;
+  margin-top: 10px; }
+  .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+    text-align: left; }
+
+.kt-svg-testimonial-global-icon {
+  border: 2px solid #eeeeee;
+  border-radius: 100%;
+  background: transparent;
+  color: #444444;
+  padding: 20px; }
+
+.kt-svg-testimonial-global-icon-wrap {
+  margin: 0 0 10px 0; }
+
+.kt-testimonial-style-card .kt-testimonial-media-inner-wrap {
+  width: auto;
+  margin: 0 0 15px 0;
+  border-radius: 0; }
+  .kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic {
+    padding-bottom: 50%; }
+  .kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kt-testimonial-image, .kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kt-testimonial-image-placeholder {
+    border-radius: 0; }
+
+.kt-testimonial-style-card .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+  text-align: center; }
+
+.kt-testimonial-style-card.kt-testimonials-icon-on.kt-testimonial-halign-center .kt-testimonial-item-wrap {
+  text-align: left; }
+
+.kt-testimonial-style-card .kt-svg-testimonial-global-icon-wrap {
+  float: left;
+  margin: 0 10px 0 0; }
+
+.kt-testimonial-style-card.kt-testimonial-halign-right .kt-svg-testimonial-global-icon-wrap {
+  float: right; }
+
+.kt-testimonial-style-card.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap {
+  margin: 0 0 15px 0; }
+
+.kt-testimonial-style-bubble .kt-testimonial-text-wrap {
+  border: 2px solid #eee;
+  padding: 20px;
+  position: relative;
+  border-radius: 10px; }
+  .kt-testimonial-style-bubble .kt-testimonial-text-wrap:after {
+    height: 0;
+    left: 50%;
+    top: 100%;
+    position: absolute;
+    border-top: 14px solid #eee;
+    border-bottom: 14px solid transparent;
+    border-left: 14px solid transparent;
+    border-right: 14px solid transparent;
+    content: '';
+    -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+            transform: translateX(-50%);
+    width: 0; }
+
+.kt-testimonial-style-bubble .kt-testimonial-meta-wrap {
+  margin-top: 20px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-left .kt-testimonial-meta-wrap {
+  margin-left: 6px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-left.kt-testimonials-media-off .kt-testimonial-meta-wrap {
+  margin-left: 20px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-right .kt-testimonial-meta-wrap {
+  margin-right: 6px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-right.kt-testimonials-media-off .kt-testimonial-meta-wrap {
+  margin-right: 20px; }
+
+.kt-testimonial-style-bubble .kt-svg-testimonial-global-icon {
+  background: #fff; }
+
+.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap {
+  margin: -55px 0 10px 0; }
+
+.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-testimonial-item-wrap {
+  padding-top: 55px; }
+
+.kt-testimonial-halign-center.kt-testimonials-media-off .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+  text-align: center; }
+
+.kt-testimonial-style-inlineimage .kt-testimonial-media-wrap {
+  float: left; }
+
+.kt-testimonial-style-inlineimage .kt-testimonial-text-wrap {
+  border: 2px solid #eee;
+  padding: 20px;
+  position: relative;
+  border-radius: 10px;
+  text-align: left; }
+  .kt-testimonial-style-inlineimage .kt-testimonial-text-wrap:after {
+    height: 0;
+    left: 20px;
+    top: 100%;
+    position: absolute;
+    border-top: 14px solid #eee;
+    border-bottom: 14px solid transparent;
+    border-left: 14px solid transparent;
+    border-right: 14px solid transparent;
+    content: '';
+    -webkit-transform: none;
+        -ms-transform: none;
+            transform: none;
+    width: 0; }
+
+.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap {
+  margin-top: 2px;
+  -ms-flex-pack: start;
+      justify-content: flex-start;
+  padding-left: 60px; }
+  .kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+    text-align: left;
+    display: -ms-flexbox;
+    display: flex; }
+    .kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap .kt-testimonial-name-wrap {
+      padding-right: 6px; }
+
+.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-text-wrap {
+  text-align: left; }
+
+.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-media-wrap {
+  float: right; }
+
+.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-meta-wrap {
+  padding-left: 0px;
+  padding-right: 60px; }
+
+.kt-testimonial-style-inlineimage .kt-svg-testimonial-global-icon {
+  background: #fff; }
+
+.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap {
+  margin: -55px 0 10px 0; }
+
+.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-testimonial-item-wrap {
+  padding-top: 55px; }
+
+.kt-testimonial-halign-left .kt-testimonial-item-wrap {
+  text-align: left;
+  margin: 0; }
+  .kt-testimonial-halign-left .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap {
+    text-align: left; }
+
+.kt-testimonial-halign-left .kt-testimonial-meta-wrap {
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+
+.kt-testimonial-halign-left .kt-testimonial-text-wrap:after {
+  left: 20px;
+  -webkit-transform: none;
+      -ms-transform: none;
+          transform: none; }
+
+.kt-testimonial-halign-right .kt-testimonial-item-wrap {
+  text-align: right;
+  margin-left: auto;
+  margin-right: 0; }
+  .kt-testimonial-halign-right .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap {
+    text-align: right; }
+
+.kt-testimonial-halign-right .kt-testimonial-meta-wrap {
+  -ms-flex-pack: start;
+      justify-content: flex-start;
+  -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse; }
+
+.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap {
+  margin: 0 0 0 15px; }
+
+.kt-testimonial-halign-right .kt-testimonial-text-wrap:after {
+  left: auto;
+  right: 20px;
+  -webkit-transform: none;
+      -ms-transform: none;
+          transform: none; }
+
+.kt-testimonial-name a {
+  color: inherit; }
+
+.kt-testimonial-occupation a {
+  color: inherit; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for Backend.
+ */
+.components-button-group.kt-style-btn-group.kb-gallery-type-select button.components-button.kt-style-btn {
+  width: 33%; }
+
+.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-container > .components-form-file-upload {
+  margin-top: 10px; }
+  .wp-block[data-type="kadence/advancedgallery"] .kb-gallery-container > .components-form-file-upload .editor-media-placeholder {
+    margin: 0; }
+
+.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-container > .components-placeholder.wp-block-kadence-advancedgallery {
+  margin-top: 10px; }
+
+.kb-image-size-container .kb-gallery-type-select-form-row {
+  margin-bottom: 10px;
+  z-index: 220;
+  position: relative; }
+
+.kb-gallery-custom-link {
+  position: relative;
+  z-index: 2;
+  padding: 0 4px 4px;
+  display: block; }
+
+.kb-gallery-custom-link .block-editor-url-input {
+  width: 100%;
+  border-top: 4px solid #0085ba; }
+
+.kb-gallery-custom-link .block-editor-url-input input[type=text] {
+  width: 100%;
+  margin: 0;
+  line-height: 18px;
+  padding-right: 40px; }
+
+.kb-gallery-custom-link .block-editor-url-popover__settings-toggle {
+  position: absolute;
+  right: 4px;
+  top: 4px; }
+
+.wp-block-kadence-advancedgallery {
+  overflow: hidden; }
+
+.kb-gallery-main-contain li {
+  list-style-type: none; }
+
+.kadence-blocks-gallery-item figure:not(.is-selected):focus {
+  outline: none; }
+
+.kadence-blocks-gallery-item .is-selected {
+  outline: 0; }
+  .kadence-blocks-gallery-item .is-selected:before {
+    content: '';
+    position: absolute;
+    border: 4px solid #0085ba;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 1; }
+  .kadence-blocks-gallery-item .is-selected .kb-gallery-image-contain {
+    outline: 0; }
+
+.kadence-blocks-gallery-item .is-transient img {
+  opacity: 0.3; }
+
+.kadence-blocks-gallery-item .block-editor-rich-text {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  max-height: 100%;
+  overflow-y: auto; }
+
+.kadence-blocks-gallery-item figcaption {
+  max-height: 100%;
+  overflow-y: auto; }
+
+.kadence-blocks-gallery-item .block-editor-rich-text figcaption:not([data-is-placeholder-visible="true"]) {
+  position: relative;
+  overflow: hidden; }
+
+.kadence-blocks-gallery-item .is-selected .block-editor-rich-text {
+  z-index: 2; }
+  @supports ((position: -webkit-sticky) or (position: sticky)) {
+    .kadence-blocks-gallery-item .is-selected .block-editor-rich-text {
+      right: 0;
+      left: 0;
+      margin-top: -4px; } }
+  .kadence-blocks-gallery-item .is-selected .block-editor-rich-text .block-editor-rich-text__inline-toolbar {
+    top: 0; }
+
+.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__move-menu,
+.kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__inline-menu {
+  background-color: #0085ba; }
+  .kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__move-menu .components-button,
+  .kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__inline-menu .components-button {
+    color: #f4f4f4; }
+  .kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__move-menu .components-button:focus,
+  .kadence-blocks-gallery-item .is-selected .kadence-blocks-library-gallery-item__inline-menu .components-button:focus {
+    color: inherit; }
+
+.kadence-blocks-gallery-item figcaption .block-editor-rich-text a {
+  color: #f4f4f4; }
+
+.kb-gallery-caption-style-below .kadence-blocks-gallery-item .block-editor-rich-text {
+  position: relative;
+  overflow: visible; }
+
+.kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-slider .slick-slide.slick-current {
+  z-index: 10; }
+
+.kb-gallery-caption-style-below .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .is-selected .block-editor-rich-text {
+  margin-top: 0; }
+
+.kb-gallery-caption-style-below .kadence-blocks-gallery-item .is-selected .block-editor-rich-text .block-editor-rich-text__inline-toolbar {
+  top: -40px; }
+
+.kadence-blocks-library-gallery-item__move-menu,
+.kadence-blocks-library-gallery-item__inline-menu {
+  padding: 2px;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  z-index: 20; }
+  .kadence-blocks-library-gallery-item__move-menu .components-button,
+  .kadence-blocks-library-gallery-item__inline-menu .components-button {
+    color: transparent; }
+
+.kadence-blocks-library-gallery-item__inline-menu {
+  position: absolute;
+  top: 0px;
+  right: 0px; }
+
+.kadence-blocks-library-gallery-item__move-menu {
+  position: absolute;
+  top: 0px;
+  left: 0px; }
+
+.kadence-blocks-gallery-item__move-backward,
+.kadence-blocks-gallery-item__move-forward,
+.kadence-blocks-gallery-item__remove {
+  padding: 0; }
+
+.kadence-blocks-gallery-item .components-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-top: -9px;
+  margin-left: -9px; }
+
+.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain {
+  margin: -5px; }
+
+.kb-gallery-main-contain {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  list-style-type: none;
+  padding: 0; }
+  .kb-gallery-main-contain .kadence-blocks-gallery-item {
+    position: relative;
+    padding: 5px;
+    margin: 0; }
+    .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner {
+      position: relative;
+      margin-bottom: 0; }
+      .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure {
+        margin: 0; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gal-image-radius {
+          position: relative;
+          overflow: hidden;
+          margin: 0 auto; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain {
+          border: 0;
+          background: transparent;
+          padding: 0;
+          margin: 0;
+          display: block;
+          width: 100%;
+          -webkit-transition: all .3s ease-in-out;
+          -o-transition: all .3s ease-in-out;
+          transition: all .3s ease-in-out; }
+          .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic {
+            height: 0;
+            position: relative; }
+            .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic img {
+              position: absolute;
+              -ms-flex: 1;
+                  flex: 1;
+              height: 100%;
+              -o-object-fit: cover;
+                 object-fit: cover;
+              width: 100%;
+              top: 0;
+              left: 0; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-square {
+          padding-bottom: 100%; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land43 {
+          padding-bottom: 75%; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land32 {
+          padding-bottom: 66.67%; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land21 {
+          padding-bottom: 50%; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land31 {
+          padding-bottom: 33%; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land41 {
+          padding-bottom: 25%; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port34 {
+          padding-bottom: 133.33%; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port23 {
+          padding-bottom: 150%; }
+      .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img {
+        display: block;
+        max-width: 100%;
+        height: auto; }
+      .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img {
+        width: 100%; }
+        @supports ((position: -webkit-sticky) or (position: sticky)) {
+          .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img {
+            width: auto; } }
+      .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption {
+        width: 100%;
+        max-height: 100%;
+        overflow: visible;
+        padding: 43px 10px 10px;
+        font-size: 13px;
+        color: #f4f4f4;
+        text-align: center;
+        background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(41, 41, 41, 0.5)), to(rgba(41, 41, 41, 0)));
+        background: -webkit-linear-gradient(bottom, rgba(41, 41, 41, 0.5) 0, rgba(41, 41, 41, 0) 100%);
+        background: -o-linear-gradient(bottom, rgba(41, 41, 41, 0.5) 0, rgba(41, 41, 41, 0) 100%);
+        background: linear-gradient(0deg, rgba(41, 41, 41, 0.5) 0, rgba(41, 41, 41, 0) 100%); }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption img {
+          display: inline; }
+        .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption.editing-caption {
+          padding-top: 48px; }
+      .kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kadence-blocks-gallery-item-hide-caption figcaption {
+        display: none; }
+  .kb-gallery-main-contain .kadence-blocks-gallery-item {
+    width: 100%; }
+  @media (min-width: 600px) {
+    .kb-gallery-main-contain[data-columns-xxl="2"] .kadence-blocks-gallery-item {
+      width: 50%; }
+    .kb-gallery-main-contain[data-columns-xxl="3"] .kadence-blocks-gallery-item {
+      width: 33.33333%; }
+    .kb-gallery-main-contain[data-columns-xxl="4"] .kadence-blocks-gallery-item {
+      width: 25%; }
+    .kb-gallery-main-contain[data-columns-xxl="5"] .kadence-blocks-gallery-item {
+      width: 20%; }
+    .kb-gallery-main-contain[data-columns-xxl="6"] .kadence-blocks-gallery-item {
+      width: 16.66667%; }
+    .kb-gallery-main-contain[data-columns-xxl="7"] .kadence-blocks-gallery-item {
+      width: 14.28571%; }
+    .kb-gallery-main-contain[data-columns-xxl="8"] .kadence-blocks-gallery-item {
+      width: 12.5%; } }
+
+.kb-gallery-caption-style-below .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption.kadence-blocks-gallery-item__caption {
+  padding: 10px;
+  margin-top: 0;
+  background: rgba(0, 0, 0, 0.5); }
+
+.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item figcaption {
+  opacity: 0;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  -o-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out; }
+
+.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item:hover figcaption, .kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item .is-selected figcaption {
+  opacity: 1; }
+
+.kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .block-editor-rich-text {
+  top: 0;
+  margin: 0; }
+
+.kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  padding: 10px;
+  margin: 0;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  -o-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
+  background: rgba(0, 0, 0, 0.5); }
+
+.kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item:hover figcaption, .kb-gallery-main-contain.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .is-selected figcaption {
+  opacity: 1; }
+
+.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain.kb-gallery-type-carousel, .wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain.kb-gallery-type-fluidcarousel, .wp-block[data-type="kadence/advancedgallery"] .kb-gallery-main-contain.kb-gallery-type-slider {
+  margin: 0; }
+
+.kb-gallery-main-contain.kb-gallery-type-carousel, .kb-gallery-main-contain.kb-gallery-type-slider {
+  display: block; }
+  .kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider, .kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-slider {
+    margin: 0 -5px;
+    -webkit-user-select: auto;
+       -moz-user-select: auto;
+        -ms-user-select: auto;
+            user-select: auto;
+    -ms-touch-action: auto;
+        touch-action: auto; }
+    .kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider .slick-slide, .kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-slider .slick-slide {
+      padding: 4px 5px; }
+  .kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-prev, .kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-prev {
+    left: 5px; }
+  .kb-gallery-main-contain.kb-gallery-type-carousel .kt-blocks-carousel .slick-next, .kb-gallery-main-contain.kb-gallery-type-slider .kt-blocks-carousel .slick-next {
+    right: 5px; }
+  .kb-gallery-main-contain.kb-gallery-type-carousel .slick-slider .kadence-blocks-gallery-item, .kb-gallery-main-contain.kb-gallery-type-slider .slick-slider .kadence-blocks-gallery-item {
+    padding: 0 !important; }
+
+.kb-gallery-main-contain.kb-gallery-type-fluidcarousel {
+  display: block; }
+  .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-slider {
+    margin: 0;
+    -webkit-user-select: auto;
+       -moz-user-select: auto;
+        -ms-user-select: auto;
+            user-select: auto;
+    -ms-touch-action: auto;
+        touch-action: auto; }
+    .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-slider .slick-slide {
+      padding: 4px 5px; }
+  .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel.kb-carousel-mode-align-left .slick-slider .slick-slide {
+    padding: 4px 10px 4px 0; }
+  .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-prev {
+    left: 0px; }
+  .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-next {
+    right: 0px; }
+  .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kadence-blocks-gallery-item {
+    padding: 0 !important; }
+
+.kb-gallery-main-contain.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit {
+  padding-bottom: 100%; }
+  .kb-gallery-main-contain.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img {
+    -o-object-fit: contain;
+       object-fit: contain; }
+
+.kb-gallery-type-carousel > .kt-blocks-carousel > .kadence-blocks-gallery-item {
+  float: left; }
+
+.kb-gallery-main-contain .kt-blocks-carousel:after {
+  clear: both;
+  display: table;
+  content: ''; }
+
+.kb-gallery-main-contain.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit {
+  padding-bottom: 66.67%; }
+  .kb-gallery-main-contain.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img {
+    -o-object-fit: contain;
+       object-fit: contain; }
+
+.kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-list figure {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column; }
+  .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-list figure .kb-gal-image-radius {
+    height: 300px;
+    width: auto;
+    margin: 0 auto; }
+    .kb-gallery-main-contain.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-list figure .kb-gal-image-radius img {
+      height: 300px;
+      width: auto;
+      -ms-flex: 1;
+          flex: 1;
+      -o-object-fit: cover;
+         object-fit: cover; }
+
+.kb-gallery-type-carousel .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after, .kb-gallery-type-slider .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after {
+  display: none; }
+
+.kb-gallery-main-contain.kb-gallery-type-carousel .kb-has-image-ratio-inherit .kb-gal-image-radius, .kb-gallery-main-contain.kb-gallery-type-slider .kb-has-image-ratio-inherit .kb-gal-image-radius {
+  border-radius: 0; }
+
+.kb-gallery-filter-vintage .kb-gallery-image-contain:after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  -webkit-box-shadow: inset 0 0 100px rgba(0, 0, 20, 0.4), inset 0 5px 15px rgba(0, 0, 0, 0.1);
+          box-shadow: inset 0 0 100px rgba(0, 0, 20, 0.4), inset 0 5px 15px rgba(0, 0, 0, 0.1);
+  background: -webkit-linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), -webkit-linear-gradient(70deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%);
+  background: -o-linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), -o-linear-gradient(70deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%);
+  background: linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), linear-gradient(20deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%); }
+
+.kb-gallery-filter-vintage .kb-gallery-image-contain img {
+  -webkit-filter: sepia(0.2) brightness(1.1) contrast(1.3);
+          filter: sepia(0.2) brightness(1.1) contrast(1.3); }
+
+.kb-gallery-filter-grayscale .kb-gallery-image-contain img {
+  -webkit-filter: grayscale(1);
+          filter: grayscale(1); }
+
+.kb-gallery-filter-sepia .kb-gallery-image-contain img {
+  -webkit-filter: sepia(0.5);
+          filter: sepia(0.5); }
+
+.kb-gallery-filter-saturation .kb-gallery-image-contain img {
+  -webkit-filter: saturate(1.6);
+          filter: saturate(1.6); }
+
+.kb-gallery-filter-earlybird .kb-gallery-image-contain::after {
+  background: -webkit-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  background: -o-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  background: radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  mix-blend-mode: overlay;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0; }
+
+.kb-gallery-filter-earlybird .kb-gallery-image-contain img {
+  -webkit-filter: contrast(0.9) sepia(0.2);
+          filter: contrast(0.9) sepia(0.2); }
+
+.kb-gallery-filter-toaster .kb-gallery-image-contain::after {
+  background: -webkit-radial-gradient(circle, #804e0f, #3b003b);
+  background: -o-radial-gradient(circle, #804e0f, #3b003b);
+  background: radial-gradient(circle, #804e0f, #3b003b);
+  mix-blend-mode: screen;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0; }
+
+.kb-gallery-filter-toaster .kb-gallery-image-contain img {
+  -webkit-filter: contrast(1.5) brightness(0.9);
+          filter: contrast(1.5) brightness(0.9); }
+
+.kb-gallery-filter-mayfair .kb-gallery-image-contain::after {
+  background: -webkit-radial-gradient(40% 40%, circle, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  background: -o-radial-gradient(40% 40%, circle, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  mix-blend-mode: overlay;
+  opacity: .4;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0; }
+
+.kb-gallery-filter-mayfair .kb-gallery-image-contain img {
+  -webkit-filter: contrast(1.1) saturate(1.1);
+          filter: contrast(1.1) saturate(1.1); }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.kt-block-default-palette .components-color-palette__item {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-colors-add-new {
+  margin-bottom: 16px; }
+
+.kb-colors-show-notice {
+  background: #fef8ee;
+  padding: 10px;
+  color: #222; }
+
+.components-popover.kt-popover-color > .components-popover__content > .components-base-control {
+  padding: 0 10px; }
+
+.kt-block-default-palette .components-color-palette__item-wrapper {
+  -webkit-transform: scale(1.1);
+      -ms-transform: scale(1.1);
+          transform: scale(1.1); }
+
+.kt-block-default-palette .components-color-palette__item-wrapper:hover {
+  -webkit-transform: scale(1.1);
+      -ms-transform: scale(1.1);
+          transform: scale(1.1); }
+
+.kt-block-default-palette .components-color-palette__item svg {
+  color: #646464; }
+
+.kt-colors-remove-last {
+  display: inline-block;
+  height: 28px;
+  width: 28px;
+  margin-right: 14px;
+  margin-bottom: 14px; }
+
+.kt-colors-remove-last .components-button {
+  border-radius: 50%;
+  height: 100%;
+  width: 100%;
+  padding: 0;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-blocks-width-control, .kt-blocks-control-wrap {
+  padding: 10px; }
+
+.components-button-group .kt-editor-width-btn {
+  background: transparent;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  border: 1px solid #eee;
+  padding: 8px;
+  margin-right: 0px;
+  height: auto;
+  width: 100%;
+  font-size: 13px;
+  margin-bottom: 5px;
+  text-shadow: none; }
+
+.components-button-group .kt-editor-width-btn:hover, .components-button-group .kt-editor-width-btn.is-primary, .components-button-group .kt-editor-width-btn:focus:not(:disabled):not([aria-disabled=true]) {
+  border-color: #444;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  background: #777;
+  color: white; }
+
+.components-button-group .kt-editor-width-btn.is-primary, .components-button-group .kt-editor-width-btn:focus:not(:disabled):not([aria-disabled=true]) {
+  background: #444; }
+
+.kt-blocks-control-wrap .kt-block-defaults {
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  -ms-flex-align: center;
+      align-items: center;
+  line-height: 24px;
+  background: #fff;
+  border: 1px solid #ddd;
+  text-align: left;
+  color: #444;
+  width: 80%;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  margin-bottom: 10px; }
+  .kt-blocks-control-wrap .kt-block-defaults span.kt-block-icon {
+    display: block;
+    height: 20px;
+    margin-right: 10px; }
+
+.kt-blocks-control-wrap .kt-block-defaults:hover {
+  background: #f9f9f9; }
+
+.kt-blocks-control-wrap .kt-block-defaults:focus {
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kt-blocks-control-wrap .kt-block-settings {
+  width: 16%;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  padding: 6px 10px;
+  font-weight: 600;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #ddd;
+  text-align: left;
+  color: #555;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  margin-left: 2%;
+  margin-bottom: 10px; }
+
+.kt-blocks-control-wrap .kt-block-settings:hover {
+  background: #f9f9f9; }
+
+.kt-blocks-control-wrap .kt-block-settings:focus {
+  -webkit-box-shadow: none;
+          box-shadow: none; }
+
+.kt-block-settings-modal .components-modal__header h1, .kt-block-defaults-modal .components-modal__header h1 {
+  font-size: 14px;
+  font-weight: bold; }
+
+.kt-block-defaults-modal button.components-button.kt-defaults-save, .kt-block-settings-modal button.components-button.kt-settings-save {
+  margin-top: 10px; }
+
+@media (min-width: 600px) {
+  .kt-block-defaults-modal {
+    width: 400px; } }
+
+.kt-block-defaults-modal p {
+  margin-top: 0; }
+
+.kt-block-defaults-modal .components-color-palette {
+  padding-bottom: 5px; }
+  .kt-block-defaults-modal .components-color-palette:after {
+    clear: both;
+    display: table;
+    content: ''; }
+
+.kt-block-defaults-modal .components-panel__body .components-base-control {
+  margin-bottom: 24px; }
+
+.kt-block-defaults-modal .components-panel__body:last-child {
+  margin-bottom: -16px; }
+
+.kt-block-defaults-modal .components-panel__body:first-child {
+  margin-top: 16px; }
+
+.kt-block-defaults-modal .components-panel__body {
+  border: none;
+  border-top: 1px solid #e2e4e7;
+  margin: 0 -16px; }
+
+.kt-font-family-modal {
+  min-height: 480px; }

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -1,11 +1,3276 @@
-.kt-block-spacer{position:relative;height:60px}.kt-block-spacer .kt-divider{width:100%;border-top:solid 1px #eee;position:absolute;top:50%;left:50%;margin:0;padding:0;border-bottom:0;border-left:0;border-right:0;-webkit-transform:perspective(1px) translate(-50%, -50%);transform:perspective(1px) translate(-50%, -50%)}.kt-block-spacer.kt-block-spacer-halign-left .kt-divider{left:0;-webkit-transform:perspective(1px) translate(0%, -50%);transform:perspective(1px) translate(0%, -50%)}.kt-block-spacer.kt-block-spacer-halign-right .kt-divider{left:auto;right:0;-webkit-transform:perspective(1px) translate(0%, -50%);transform:perspective(1px) translate(0%, -50%)}
-.kt-button{padding:8px 16px;z-index:1;position:relative;cursor:pointer;font-size:18px;display:-ms-flexbox;display:flex;line-height:1.6;text-decoration:none;text-align:center;-ms-flex-pack:center;justify-content:center;border-style:solid;-webkit-transition:all .3s ease-in-out;-o-transition:all .3s ease-in-out;transition:all .3s ease-in-out;border-width:2px;border-radius:3px;border-color:#555555;overflow:hidden;background:transparent;color:#555555}.kt-button::before{position:absolute;content:"";top:0;right:0;bottom:0;left:0;z-index:-1;opacity:0;background:#444444;-webkit-transition:all .3s ease-in-out;-o-transition:all .3s ease-in-out;transition:all .3s ease-in-out}.kt-button:hover,.kt-button:focus{border-color:#444444;color:#ffffff}.kt-button:hover::before,.kt-button:focus::before{opacity:1}.kt-btn-size-small{font-size:16px;padding:4px 8px;border-width:1px}.kt-btn-size-large{font-size:20px;padding:12px 24px;border-width:3px}.kt-btn-svg-icon.kt-btn-side-right{padding-left:5px}.kt-btn-svg-icon.kt-btn-side-left{padding-right:5px}.kt-btn-has-text-false .kt-btn-svg-icon{padding-left:0;padding-right:0}.kt-btn-wrap{display:inline-block;margin-bottom:5px}.kt-btn-align-center{text-align:center}.kt-btn-align-left{text-align:left}.kt-btn-align-right{text-align:right}.wp-block-kadence-advancedbtn .kt-btn-wrap:last-child{margin-right:0}.wp-block-kadence-advancedbtn .kt-btn-wrap{margin-right:5px}.kt-force-btn-fullwidth{display:-ms-flexbox;display:flex}.kt-force-btn-fullwidth .kt-btn-wrap{display:block;-ms-flex-positive:1;flex-grow:1}.kt-force-btn-fullwidth .kt-btn-wrap .kt-button{-ms-flex-pack:center;justify-content:center}@media (min-width: 768px) and (max-width: 1024px){.kt-btn-tablet-align-center{text-align:center}.kt-btn-tablet-align-left{text-align:left}.kt-btn-tablet-align-right{text-align:right}}@media (max-width: 767px){.kt-btn-mobile-align-center{text-align:center}.kt-btn-mobile-align-left{text-align:left}.kt-btn-mobile-align-right{text-align:right}}
-.kt-row-layout-inner{position:relative}.kt-row-column-wrap{padding:25px 0 25px 0;display:-ms-flexbox;display:flex;-ms-flex-wrap:nowrap;flex-wrap:nowrap;-ms-flex-pack:justify;justify-content:space-between;position:relative;z-index:10}.kt-row-has-bg>.kt-row-column-wrap{padding-left:15px;padding-right:15px}.alignfull .kt-row-column-wrap{padding-left:15px;padding-right:15px}.wp-block-kadence-column{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;z-index:1;min-width:0;min-height:0}.kt-inner-column-height-full>.wp-block-kadence-column>.kt-inside-inner-col{height:100%}.wp-block-kadence-rowlayout:before{clear:both;content:'';display:table}.kt-row-layout-overlay{top:0;left:0;position:absolute;opacity:0.3;height:100%;width:100%;z-index:0}.kt-inside-inner-col{border:0 solid transparent;-ms-flex-negative:0}.kt-row-valign-middle>.wp-block-kadence-column{-ms-flex-pack:center;justify-content:center}.kt-row-valign-bottom>.wp-block-kadence-column{-ms-flex-pack:end;justify-content:flex-end}#content .entry-content .wp-block-kadence-rowlayout.alignfull,#content .entry-content .wp-block-kadence-rowlayout.alignwide{text-align:inherit;margin-bottom:0}@media (min-width: 767px){.kt-row-layout-equal>.wp-block-kadence-column{-ms-flex:1;flex:1;width:0}.kt-row-layout-row{-ms-flex-direction:column;flex-direction:column}.kt-row-layout-row>.wp-block-kadence-column{-ms-flex:none;flex:none;width:100%;margin-right:0}.kt-row-layout-row.kt-v-gutter-default>.wp-block-kadence-column{margin-bottom:30px}.kt-row-layout-row.kt-v-gutter-skinny>.wp-block-kadence-column{margin-bottom:10px}.kt-row-layout-row.kt-v-gutter-narrow>.wp-block-kadence-column{margin-bottom:20px}.kt-row-layout-row.kt-v-gutter-wide>.wp-block-kadence-column{margin-bottom:40px}.kt-row-layout-row.kt-v-gutter-wider>.wp-block-kadence-column{margin-bottom:60px}.kt-row-layout-row.kt-v-gutter-widest>.wp-block-kadence-column{margin-bottom:80px}.kt-row-layout-row:not(.kt-v-gutter-none)>.wp-block-kadence-column:last-child{margin-bottom:0px}.kt-gutter-default>.wp-block-kadence-column{margin-right:30px}.kt-gutter-skinny>.wp-block-kadence-column{margin-right:10px}.kt-gutter-narrow>.wp-block-kadence-column{margin-right:20px}.kt-gutter-wide>.wp-block-kadence-column{margin-right:40px}.kt-gutter-wider>.wp-block-kadence-column{margin-right:60px}.kt-gutter-widest>.wp-block-kadence-column{margin-right:80px}.kt-row-column-wrap:not(.kt-gutter-none)>.wp-block-kadence-column:last-child{margin-right:0px}.kt-gutter-skinny.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex-preferred-size:10px;flex-basis:10px}.kt-gutter-skinny.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex-preferred-size:10px;flex-basis:10px}.kt-gutter-narrow.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex-preferred-size:20px;flex-basis:20px}.kt-gutter-narrow.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex-preferred-size:20px;flex-basis:20px}.kt-gutter-default.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex-preferred-size:30px;flex-basis:30px}.kt-gutter-default.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex-preferred-size:30px;flex-basis:30px}.kt-gutter-wide.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex-preferred-size:40px;flex-basis:40px}.kt-gutter-wide.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex-preferred-size:40px;flex-basis:40px}.kt-gutter-wider.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex-preferred-size:60px;flex-basis:60px}.kt-gutter-wider.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex-preferred-size:60px;flex-basis:60px}.kt-gutter-widest.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex-preferred-size:80px;flex-basis:80px}.kt-gutter-widest.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex-preferred-size:80px;flex-basis:80px}.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-row-layout-left-golden>.wp-block-kadence-column.inner-column-2{-ms-flex:1;flex:1}.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-1{-ms-flex:1;flex:1}.kt-row-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex:2;flex:2}.kt-has-2-columns.kt-custom-first-width-10>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 10%;flex:0 1 10%}.kt-has-2-columns.kt-custom-first-width-10>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 90%;flex:0 1 90%}.kt-has-2-columns.kt-custom-first-width-15>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 15%;flex:0 1 15%}.kt-has-2-columns.kt-custom-first-width-15>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 85%;flex:0 1 85%}.kt-has-2-columns.kt-custom-first-width-20>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 20%;flex:0 1 20%}.kt-has-2-columns.kt-custom-first-width-20>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 80%;flex:0 1 80%}.kt-has-2-columns.kt-custom-first-width-25>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 25%;flex:0 1 25%}.kt-has-2-columns.kt-custom-first-width-25>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 75%;flex:0 1 75%}.kt-has-2-columns.kt-custom-first-width-30>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 30%;flex:0 1 30%}.kt-has-2-columns.kt-custom-first-width-30>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 70%;flex:0 1 70%}.kt-has-2-columns.kt-custom-first-width-35>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 35%;flex:0 1 35%}.kt-has-2-columns.kt-custom-first-width-35>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 65%;flex:0 1 65%}.kt-has-2-columns.kt-custom-first-width-40>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 40%;flex:0 1 40%}.kt-has-2-columns.kt-custom-first-width-40>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 60%;flex:0 1 60%}.kt-has-2-columns.kt-custom-first-width-45>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 45%;flex:0 1 45%}.kt-has-2-columns.kt-custom-first-width-45>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 55%;flex:0 1 55%}.kt-has-2-columns.kt-custom-first-width-50>.wp-block-kadence-column.inner-column-1{-ms-flex:1;flex:1}.kt-has-2-columns.kt-custom-first-width-50>.wp-block-kadence-column.inner-column-2{-ms-flex:1;flex:1}.kt-has-2-columns.kt-custom-first-width-55>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 55%;flex:0 1 55%}.kt-has-2-columns.kt-custom-first-width-55>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 45%;flex:0 1 45%}.kt-has-2-columns.kt-custom-first-width-60>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 60%;flex:0 1 60%}.kt-has-2-columns.kt-custom-first-width-60>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 40%;flex:0 1 40%}.kt-has-2-columns.kt-custom-first-width-65>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 65%;flex:0 1 65%}.kt-has-2-columns.kt-custom-first-width-65>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 35%;flex:0 1 35%}.kt-has-2-columns.kt-custom-first-width-70>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 70%;flex:0 1 70%}.kt-has-2-columns.kt-custom-first-width-70>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 30%;flex:0 1 30%}.kt-has-2-columns.kt-custom-first-width-75>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 75%;flex:0 1 75%}.kt-has-2-columns.kt-custom-first-width-75>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 25%;flex:0 1 25%}.kt-has-2-columns.kt-custom-first-width-80>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 80%;flex:0 1 80%}.kt-has-2-columns.kt-custom-first-width-80>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 20%;flex:0 1 20%}.kt-has-2-columns.kt-custom-first-width-85>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 85%;flex:0 1 85%}.kt-has-2-columns.kt-custom-first-width-85>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 15%;flex:0 1 15%}.kt-has-2-columns.kt-custom-first-width-90>.wp-block-kadence-column.inner-column-1{-ms-flex:0 1 90%;flex:0 1 90%}.kt-has-2-columns.kt-custom-first-width-90>.wp-block-kadence-column.inner-column-2{-ms-flex:0 1 10%;flex:0 1 10%}.kt-row-layout-left-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-row-layout-left-half>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-row-layout-right-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-row-layout-right-half>.wp-block-kadence-column.inner-column-3{-ms-flex:2;flex:2}.kt-row-layout-center-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-row-layout-center-half>.wp-block-kadence-column.inner-column-2{-ms-flex:2;flex:2}.kt-row-layout-center-wide>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-row-layout-center-wide>.wp-block-kadence-column.inner-column-2{-ms-flex:3;flex:3}.kt-row-layout-center-exwide>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-row-layout-center-exwide>.wp-block-kadence-column.inner-column-2{-ms-flex:6;flex:6}.kt-row-layout-left-forty>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-row-layout-left-forty>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-row-layout-right-forty>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-row-layout-right-forty>.wp-block-kadence-column.inner-column-4{-ms-flex:2;flex:2}}@media (min-width: 768px) and (max-width: 1024px){.kt-row-column-wrap.kt-tab-layout-equal>.wp-block-kadence-column{-ms-flex:1;flex:1;width:0}.kt-row-layout-row:not(.kt-tab-layout-inherit){-ms-flex-direction:row;flex-direction:row}.kt-row-column-wrap.kt-tab-layout-row{-ms-flex-direction:column;flex-direction:column}.kt-row-column-wrap.kt-tab-layout-row.kt-m-colapse-right-to-left{-ms-flex-direction:column-reverse;flex-direction:column-reverse}.kt-row-column-wrap.kt-tab-layout-row>.wp-block-kadence-column{-ms-flex:none;flex:none;width:100%;margin-right:0}.kt-has-1-columns.kt-tab-layout-row>.wp-block-kadence-column.inner-column-1{-ms-flex:1;flex:1}.kt-tab-layout-row.kt-v-gutter-default>.wp-block-kadence-column{margin-bottom:30px}.kt-tab-layout-row.kt-v-gutter-skinny>.wp-block-kadence-column{margin-bottom:10px}.kt-tab-layout-row.kt-v-gutter-narrow>.wp-block-kadence-column{margin-bottom:20px}.kt-tab-layout-row.kt-v-gutter-wide>.wp-block-kadence-column{margin-bottom:40px}.kt-tab-layout-row.kt-v-gutter-wider>.wp-block-kadence-column{margin-bottom:60px}.kt-tab-layout-row.kt-v-gutter-widest>.wp-block-kadence-column{margin-bottom:80px}.kt-tab-layout-row:not(.kt-v-gutter-none)>.wp-block-kadence-column:last-child{margin-bottom:0px}.kt-tab-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-tab-layout-left-golden>.wp-block-kadence-column.inner-column-2{-ms-flex:1;flex:1}.kt-tab-layout-right-golden>.wp-block-kadence-column.inner-column-1{-ms-flex:1;flex:1}.kt-tab-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex:2;flex:2}.kt-tab-layout-left-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-left-half>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-tab-layout-right-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-right-half>.wp-block-kadence-column.inner-column-3{-ms-flex:2;flex:2}.kt-tab-layout-center-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-center-half>.wp-block-kadence-column.inner-column-2{-ms-flex:2;flex:2}.kt-tab-layout-center-wide>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-center-wide>.wp-block-kadence-column.inner-column-2{-ms-flex:3;flex:3}.kt-tab-layout-center-exwide>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-center-exwide>.wp-block-kadence-column.inner-column-2{-ms-flex:6;flex:6}.kt-tab-layout-first-row{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-tab-layout-first-row>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-first-row>.wp-block-kadence-column.inner-column-1{-ms-flex:0 0 100%;flex:0 0 100%}.kt-tab-layout-first-row.kt-v-gutter-default>.wp-block-kadence-column.inner-column-1{margin-bottom:30px}.kt-tab-layout-first-row.kt-v-gutter-skinny>.wp-block-kadence-column.inner-column-1{margin-bottom:10px}.kt-tab-layout-first-row.kt-v-gutter-narrow>.wp-block-kadence-column.inner-column-1{margin-bottom:20px}.kt-tab-layout-first-row.kt-v-gutter-wide>.wp-block-kadence-column.inner-column-1{margin-bottom:40px}.kt-tab-layout-first-row.kt-v-gutter-wider>.wp-block-kadence-column.inner-column-1{margin-bottom:60px}.kt-tab-layout-first-row.kt-v-gutter-widest>.wp-block-kadence-column.inner-column-1{margin-bottom:80px}.kt-tab-layout-last-row{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-tab-layout-last-row>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-last-row>.wp-block-kadence-column.inner-column-3{-ms-flex:0 0 100%;flex:0 0 100%}.kt-tab-layout-last-row.kt-v-gutter-default>.wp-block-kadence-column.inner-column-3{margin-top:30px}.kt-tab-layout-last-row.kt-v-gutter-skinny>.wp-block-kadence-column.inner-column-3{margin-top:10px}.kt-tab-layout-last-row.kt-v-gutter-narrow>.wp-block-kadence-column.inner-column-3{margin-top:20px}.kt-tab-layout-last-row.kt-v-gutter-wide>.wp-block-kadence-column.inner-column-3{margin-top:40px}.kt-tab-layout-last-row.kt-v-gutter-wider>.wp-block-kadence-column.inner-column-3{margin-top:60px}.kt-tab-layout-last-row.kt-v-gutter-widest>.wp-block-kadence-column.inner-column-3{margin-top:80px}.kt-tab-layout-left-forty>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-left-forty>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-tab-layout-right-forty>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-tab-layout-right-forty>.wp-block-kadence-column.inner-column-4{-ms-flex:2;flex:2}.kt-tab-layout-two-grid{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-tab-layout-two-grid.kt-m-colapse-right-to-left{-ms-flex-direction:row-reverse;flex-direction:row-reverse;-ms-flex-wrap:wrap-reverse;flex-wrap:wrap-reverse}.kt-tab-layout-two-grid.kt-gutter-default>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 15px);flex:0 0 calc( 50% - 15px)}.kt-tab-layout-two-grid.kt-gutter-skinny>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 5px);flex:0 0 calc( 50% - 5px)}.kt-tab-layout-two-grid.kt-gutter-narrow>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 10px);flex:0 0 calc( 50% - 10px)}.kt-tab-layout-two-grid.kt-gutter-wide>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 20px);flex:0 0 calc( 50% - 20px)}.kt-tab-layout-two-grid.kt-gutter-wider>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 30px);flex:0 0 calc( 50% - 30px)}.kt-tab-layout-two-grid.kt-gutter-widest>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 40px);flex:0 0 calc( 50% - 40px)}.kt-tab-layout-two-grid.kt-gutter-none>.wp-block-kadence-column{-ms-flex:0 0 50%;flex:0 0 50%}.kt-tab-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left)>.wp-block-kadence-column.inner-column-2{margin-right:0}.kt-tab-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left)>.wp-block-kadence-column.inner-column-4{margin-right:0}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-5{margin-right:0}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-3{margin-right:0}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-1{margin-right:0}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-default>.wp-block-kadence-column:last-child{margin-right:30px}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-skinny>.wp-block-kadence-column:last-child{margin-right:10px}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-narrow>.wp-block-kadence-column:last-child{margin-right:20px}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wide>.wp-block-kadence-column:last-child{margin-right:40px}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wider>.wp-block-kadence-column:last-child{margin-right:60px}.kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-widest>.wp-block-kadence-column:last-child{margin-right:80px}.kt-tab-layout-three-grid{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-tab-layout-three-grid.kt-m-colapse-right-to-left{-ms-flex-direction:row-reverse;flex-direction:row-reverse;-ms-flex-wrap:wrap-reverse;flex-wrap:wrap-reverse}.kt-tab-layout-three-grid.kt-gutter-default>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 20px);flex:0 0 calc( 33.33% - 20px)}.kt-tab-layout-three-grid.kt-gutter-skinny>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 8px);flex:0 0 calc( 33.33% - 8px)}.kt-tab-layout-three-grid.kt-gutter-narrow>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 14px);flex:0 0 calc( 33.33% - 14px)}.kt-tab-layout-three-grid.kt-gutter-wide>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 28px);flex:0 0 calc( 33.33% - 28px)}.kt-tab-layout-three-grid.kt-gutter-wider>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 40px);flex:0 0 calc( 33.33% - 40px)}.kt-tab-layout-three-grid.kt-gutter-widest>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 54px);flex:0 0 calc( 33.33% - 54px)}.kt-tab-layout-three-grid.kt-gutter-none>.wp-block-kadence-column{-ms-flex:0 0 33.33%;flex:0 0 33.33%}.kt-tab-layout-three-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left)>.wp-block-kadence-column.inner-column-3{margin-right:0}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-4{margin-right:0}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-1{margin-right:0}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-default>.wp-block-kadence-column:last-child{margin-right:30px}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-skinny>.wp-block-kadence-column:last-child{margin-right:10px}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-narrow>.wp-block-kadence-column:last-child{margin-right:20px}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wide>.wp-block-kadence-column:last-child{margin-right:40px}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wider>.wp-block-kadence-column:last-child{margin-right:60px}.kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-widest>.wp-block-kadence-column:last-child{margin-right:80px}.wp-block-kadence-rowlayout [id*="jarallax-container-"]>div{position:fixed !important;width:100% !important;left:0 !important;margin-top:0 !important;height:100vh !important;-webkit-transform:none !important;-ms-transform:none !important;transform:none !important}.wp-block-kadence-rowlayout [id*="jarallax-container-"]{-webkit-backface-visibility:hidden;backface-visibility:hidden;clip:rect(auto, auto, auto, auto)}}@media not all and (min-resolution: 0.001dpcm){@supports (-webkit-appearance: none){@media (min-width: 768px) and (max-width: 1024px){.wp-block-kadence-rowlayout [id*="jarallax-container-"]{clip:auto !important}}}}@media (max-width: 767px){.kt-row-column-wrap.kt-mobile-layout-equal>.wp-block-kadence-column{-ms-flex:1;flex:1;width:0}.kt-row-column-wrap.kt-mobile-layout-row{-ms-flex-direction:column;flex-direction:column}.kt-row-column-wrap.kt-mobile-layout-row.kt-m-colapse-right-to-left{-ms-flex-direction:column-reverse;flex-direction:column-reverse}.kt-row-column-wrap.kt-mobile-layout-row>.wp-block-kadence-column{-ms-flex:none;flex:none;width:100%;margin-right:0}.kt-mobile-layout-row.kt-v-gutter-default>.wp-block-kadence-column{margin-bottom:30px}.kt-mobile-layout-row.kt-v-gutter-skinny>.wp-block-kadence-column{margin-bottom:10px}.kt-mobile-layout-row.kt-v-gutter-narrow>.wp-block-kadence-column{margin-bottom:20px}.kt-mobile-layout-row.kt-v-gutter-wide>.wp-block-kadence-column{margin-bottom:40px}.kt-mobile-layout-row.kt-v-gutter-wider>.wp-block-kadence-column{margin-bottom:60px}.kt-mobile-layout-row.kt-v-gutter-widest>.wp-block-kadence-column{margin-bottom:80px}.kt-mobile-layout-row:not(.kt-v-gutter-none)>.wp-block-kadence-column:last-child{margin-bottom:0px}.kt-has-1-columns.kt-mobile-layout-row>.wp-block-kadence-column.inner-column-1{-ms-flex:1;flex:1}.kt-mobile-layout-left-golden>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-mobile-layout-left-golden>.wp-block-kadence-column.inner-column-2{-ms-flex:1;flex:1}.kt-mobile-layout-right-golden>.wp-block-kadence-column.inner-column-1{-ms-flex:1;flex:1}.kt-mobile-layout-right-golden>.wp-block-kadence-column.inner-column-2{-ms-flex:2;flex:2}.kt-mobile-layout-left-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-left-half>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-mobile-layout-right-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-right-half>.wp-block-kadence-column.inner-column-3{-ms-flex:2;flex:2}.kt-mobile-layout-center-half>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-center-half>.wp-block-kadence-column.inner-column-2{-ms-flex:2;flex:2}.kt-mobile-layout-center-wide>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-center-wide>.wp-block-kadence-column.inner-column-2{-ms-flex:3;flex:3}.kt-mobile-layout-center-exwide>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-center-exwide>.wp-block-kadence-column.inner-column-2{-ms-flex:6;flex:6}.kt-mobile-layout-first-row{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-mobile-layout-first-row>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-first-row>.wp-block-kadence-column.inner-column-1{-ms-flex:0 0 100%;flex:0 0 100%}.kt-mobile-layout-first-row.kt-v-gutter-default>.wp-block-kadence-column.inner-column-1{margin-bottom:30px}.kt-mobile-layout-first-row.kt-v-gutter-skinny>.wp-block-kadence-column.inner-column-1{margin-bottom:10px}.kt-mobile-layout-first-row.kt-v-gutter-narrow>.wp-block-kadence-column.inner-column-1{margin-bottom:20px}.kt-mobile-layout-first-row.kt-v-gutter-wide>.wp-block-kadence-column.inner-column-1{margin-bottom:40px}.kt-mobile-layout-first-row.kt-v-gutter-wider>.wp-block-kadence-column.inner-column-1{margin-bottom:60px}.kt-mobile-layout-first-row.kt-v-gutter-widest>.wp-block-kadence-column.inner-column-1{margin-bottom:80px}.kt-mobile-layout-last-row{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-mobile-layout-last-row>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-last-row>.wp-block-kadence-column.inner-column-3{-ms-flex:0 0 100%;flex:0 0 100%}.kt-mobile-layout-last-row.kt-v-gutter-default>.wp-block-kadence-column.inner-column-3{margin-top:30px}.kt-mobile-layout-last-row.kt-v-gutter-skinny>.wp-block-kadence-column.inner-column-3{margin-top:10px}.kt-mobile-layout-last-row.kt-v-gutter-narrow>.wp-block-kadence-column.inner-column-3{margin-top:20px}.kt-mobile-layout-last-row.kt-v-gutter-wide>.wp-block-kadence-column.inner-column-3{margin-top:40px}.kt-mobile-layout-last-row.kt-v-gutter-wider>.wp-block-kadence-column.inner-column-3{margin-top:60px}.kt-mobile-layout-last-row.kt-v-gutter-widest>.wp-block-kadence-column.inner-column-3{margin-top:80px}.kt-mobile-layout-left-forty>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-left-forty>.wp-block-kadence-column.inner-column-1{-ms-flex:2;flex:2}.kt-mobile-layout-right-forty>.wp-block-kadence-column{-ms-flex:1;flex:1}.kt-mobile-layout-right-forty>.wp-block-kadence-column.inner-column-4{-ms-flex:2;flex:2}.kt-mobile-layout-two-grid{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-mobile-layout-two-grid.kt-m-colapse-right-to-left{-ms-flex-direction:row-reverse;flex-direction:row-reverse;-ms-flex-wrap:wrap-reverse;flex-wrap:wrap-reverse}.kt-mobile-layout-two-grid.kt-gutter-default>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 15px);flex:0 0 calc( 50% - 15px)}.kt-mobile-layout-two-grid.kt-gutter-skinny>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 5px);flex:0 0 calc( 50% - 5px)}.kt-mobile-layout-two-grid.kt-gutter-narrow>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 10px);flex:0 0 calc( 50% - 10px)}.kt-mobile-layout-two-grid.kt-gutter-wide>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 20px);flex:0 0 calc( 50% - 20px)}.kt-mobile-layout-two-grid.kt-gutter-wider>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 30px);flex:0 0 calc( 50% - 30px)}.kt-mobile-layout-two-grid.kt-gutter-widest>.wp-block-kadence-column{-ms-flex:0 0 calc( 50% - 40px);flex:0 0 calc( 50% - 40px)}.kt-mobile-layout-two-grid.kt-gutter-none>.wp-block-kadence-column{-ms-flex:0 0 50%;flex:0 0 50%}.kt-mobile-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left)>.wp-block-kadence-column.inner-column-2{margin-right:0}.kt-mobile-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left)>.wp-block-kadence-column.inner-column-4{margin-right:0}.kt-mobile-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-5{margin-right:0}.kt-mobile-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-3{margin-right:0}.kt-mobile-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-1{margin-right:0}.kt-mobile-layout-three-grid{-ms-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-direction:row;flex-direction:row}.kt-mobile-layout-three-grid.kt-m-colapse-right-to-left{-ms-flex-direction:row-reverse;flex-direction:row-reverse;-ms-flex-wrap:wrap-reverse;flex-wrap:wrap-reverse}.kt-mobile-layout-three-grid.kt-gutter-default>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 20px);flex:0 0 calc( 33.33% - 20px)}.kt-mobile-layout-three-grid.kt-gutter-skinny>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 8px);flex:0 0 calc( 33.33% - 8px)}.kt-mobile-layout-three-grid.kt-gutter-narrow>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 14px);flex:0 0 calc( 33.33% - 14px)}.kt-mobile-layout-three-grid.kt-gutter-wide>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 28px);flex:0 0 calc( 33.33% - 28px)}.kt-mobile-layout-three-grid.kt-gutter-wider>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 40px);flex:0 0 calc( 33.33% - 40px)}.kt-mobile-layout-three-grid.kt-gutter-widest>.wp-block-kadence-column{-ms-flex:0 0 calc( 33.33% - 54px);flex:0 0 calc( 33.33% - 54px)}.kt-mobile-layout-three-grid.kt-gutter-none>.wp-block-kadence-column{-ms-flex:0 0 33.33%;flex:0 0 33.33%}.kt-mobile-layout-three-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left)>.wp-block-kadence-column.inner-column-3{margin-right:0}.kt-mobile-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-4{margin-right:0}.kt-mobile-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none)>.wp-block-kadence-column.inner-column-1{margin-right:0}.kt-gutter-default:not(.kt-mobile-layout-row)>.wp-block-kadence-column{margin-right:30px}.kt-gutter-skinny:not(.kt-mobile-layout-row)>.wp-block-kadence-column{margin-right:10px}.kt-gutter-narrow:not(.kt-mobile-layout-row)>.wp-block-kadence-column{margin-right:20px}.kt-gutter-wide:not(.kt-mobile-layout-row)>.wp-block-kadence-column{margin-right:40px}.kt-gutter-wider:not(.kt-mobile-layout-row)>.wp-block-kadence-column{margin-right:60px}.kt-gutter-widest:not(.kt-mobile-layout-row)>.wp-block-kadence-column{margin-right:80px}.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-mobile-layout-row):not(.kt-m-colapse-right-to-left)>.wp-block-kadence-column:last-child{margin-right:0px}.wp-block-kadence-rowlayout [id*="jarallax-container-"]>div{position:fixed !important;width:100% !important;left:0 !important;margin-top:0 !important;height:100vh !important;-webkit-transform:none !important;-ms-transform:none !important;transform:none !important}.wp-block-kadence-rowlayout [id*="jarallax-container-"]{-webkit-backface-visibility:hidden;backface-visibility:hidden;clip:rect(auto, auto, auto, auto)}}@media not all and (min-resolution: 0.001dpcm){@supports (-webkit-appearance: none){@media (max-width: 767px){.wp-block-kadence-rowlayout [id*="jarallax-container-"]{clip:auto !important}}}}.kt-row-layout-bottom-sep{position:absolute;height:100px;bottom:-1px;left:0;overflow:hidden;right:0;z-index:1}.kt-row-layout-bottom-sep svg{position:absolute;bottom:0px;left:50%;-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%);width:100.2%;height:100%;display:block}.kt-row-layout-top-sep{position:absolute;height:100px;top:-1px;left:0;overflow:hidden;right:0;z-index:1}.kt-row-layout-top-sep svg{position:absolute;top:0px;left:50%;-webkit-transform:translateX(-50%) rotate(180deg);-ms-transform:translateX(-50%) rotate(180deg);transform:translateX(-50%) rotate(180deg);width:100.2%;height:100%;display:block}.kt-row-layout-inner>.kb-blocks-bg-slider{position:absolute;left:0;right:0;top:0;bottom:0;padding:0;margin:0}.kt-row-layout-inner>.kb-blocks-bg-slider .kb-blocks-bg-slider-init{position:absolute;left:0;right:0;top:0;bottom:0;padding:0;margin:0}.kt-row-layout-inner>.kb-blocks-bg-slider .slick-dotted.slick-slider{margin:0}.kt-row-layout-inner>.kb-blocks-bg-slider .slick-track,.kt-row-layout-inner>.kb-blocks-bg-slider .slick-list,.kt-row-layout-inner>.kb-blocks-bg-slider .slick-slide,.kt-row-layout-inner>.kb-blocks-bg-slider .kb-bg-slide-contain{height:100%}.kt-row-layout-inner>.kb-blocks-bg-slider .slick-list{height:100% !important}.kt-row-layout-inner>.kb-blocks-bg-slider .kb-bg-slide-contain div.kb-bg-slide{background-position:center;background-size:cover;background-repeat:no-repeat}.kt-row-layout-inner>.kb-blocks-bg-slider .kb-blocks-bg-slider-init:not(.slick-initialized) .kb-bg-slide-contain{display:none}.kt-row-layout-inner>.kb-blocks-bg-slider .kb-blocks-bg-slider-init:not(.slick-initialized) .kb-bg-slide-contain:first-child{display:block}.kt-row-layout-inner>.kb-blocks-bg-slider .kb-bg-slide-contain div{position:relative;height:100%}.kt-row-layout-inner>.kb-blocks-bg-slider .slick-dots{bottom:0}.kt-row-layout-inner>.kb-blocks-bg-slider .slick-dots li{z-index:11}.kb-blocks-bg-video-container{bottom:0;right:0;top:0;left:0;position:absolute;overflow:hidden}.kb-blocks-bg-video{-o-object-position:50% 50%;object-position:50% 50%;-o-object-fit:cover;object-fit:cover;background-position:center center;width:100%;height:100%}.kb-background-video-buttons-wrapper{position:absolute;z-index:11;bottom:20px;right:20px}.kb-background-video-buttons-wrapper button.kb-toggle-video-btn{padding:8px;margin:0 0 0 8px;border:0;background:rgba(0,0,0,0.3);cursor:pointer;font-size:24px;color:#fff;display:inline-block;opacity:.5;height:32px;line-height:16px;-webkit-transition:opacity .3s ease-in-out;-o-transition:opacity .3s ease-in-out;transition:opacity .3s ease-in-out;-webkit-box-sizing:border-box;box-sizing:border-box}.kb-background-video-buttons-wrapper button.kb-toggle-video-btn svg{width:16px;height:16px;vertical-align:bottom}.kb-background-video-buttons-wrapper button.kb-toggle-video-btn:hover{opacity:1}
-.kt-svg-style-stacked .kt-svg-icon{border:0px solid #444444}.kt-svg-icon-wrap{display:inline-block}
-.wp-block-kadence-advancedheading mark{color:#f76a0c;background:transparent;border-style:solid;border-width:0}
-.wp-block-kadence-tabs .kt-tabs-title-list{margin:0;padding:0;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;list-style:none}.wp-block-kadence-tabs .kt-tabs-title-list li{margin:0 4px -1px 0;cursor:pointer;list-style:none}.wp-block-kadence-tabs .kt-tabs-title-list li .kt-tab-title{padding:8px 16px;display:-ms-flexbox;display:flex;color:#444;-ms-flex-align:center;align-items:center;border-style:solid;border-color:transparent;border-width:1px 1px 0 1px;border-top-left-radius:4px;border-top-right-radius:4px;text-decoration:none;-webkit-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.wp-block-kadence-tabs .kt-tabs-title-list li .kt-tab-title:focus{outline:0;text-decoration:none}.wp-block-kadence-tabs .kt-tabs-title-list li .kt-tab-title:hover{text-decoration:none}.wp-block-kadence-tabs .kt-tabs-title-list li.kt-tab-title-active{z-index:4;text-decoration:none;position:relative}.wp-block-kadence-tabs .kt-tabs-title-list li.kt-tab-title-active .kt-tab-title{background-color:#fff;border-color:#dee2e6}.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-direction:column;flex-direction:column}.kt-tabs-accordion-title.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-align:start;align-items:flex-start}.kt-tabs-accordion-title .kt-tab-title{padding:8px 16px;display:-ms-flexbox;display:flex;color:#444;-ms-flex-align:center;align-items:center;border-style:solid;border-color:transparent;border-width:1px 1px 0 1px;border-top-left-radius:4px;border-top-right-radius:4px;-webkit-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.kt-tabs-accordion-title.kt-tab-title-active{z-index:4}.kt-tabs-accordion-title.kt-tab-title-active .kt-tab-title{background-color:#fff;border-color:#dee2e6}.wp-block-kadence-tabs .kt-tab-inner-content-inner p:last-child{margin-bottom:0}.kt-tab-alignment-center>.kt-tabs-title-list,.kt-tab-alignment-center>.kt-tabs-content-wrap>.kt-tabs-accordion-title a{-ms-flex-pack:center;justify-content:center}.kt-tab-alignment-right>.kt-tabs-title-list,.kt-tab-alignment-right>.kt-tabs-content-wrap>.kt-tabs-accordion-title a{-ms-flex-pack:end;justify-content:flex-end}.kt-tabs-content-wrap:before,.kt-tabs-content-wrap:after{content:'';clear:both;display:table}.kt-tabs-content-wrap{position:relative}.kt-tabs-wrap{margin:0 auto}.kt-tabs-wrap .wp-block-kadence-tab{border:1px solid #dee2e6;padding:20px;text-align:left}.kt-tabs-wrap .wp-block-kadence-tab[role="tabpanel"]{display:none}.kt-tabs-wrap.kt-active-tab-1>.kt-tabs-content-wrap>.kt-inner-tab-1{display:block}.kt-tabs-wrap.kt-active-tab-2>.kt-tabs-content-wrap>.kt-inner-tab-2{display:block}.kt-tabs-wrap.kt-active-tab-3>.kt-tabs-content-wrap>.kt-inner-tab-3{display:block}.kt-tabs-wrap.kt-active-tab-4>.kt-tabs-content-wrap>.kt-inner-tab-4{display:block}.kt-tabs-wrap.kt-active-tab-5>.kt-tabs-content-wrap>.kt-inner-tab-5{display:block}.kt-tabs-wrap.kt-active-tab-6>.kt-tabs-content-wrap>.kt-inner-tab-6{display:block}.kt-tabs-wrap.kt-active-tab-7>.kt-tabs-content-wrap>.kt-inner-tab-7{display:block}.kt-tabs-wrap.kt-active-tab-8>.kt-tabs-content-wrap>.kt-inner-tab-8{display:block}.kt-tabs-wrap.kt-active-tab-9>.kt-tabs-content-wrap>.kt-inner-tab-9{display:block}.kt-tabs-wrap.kt-active-tab-10>.kt-tabs-content-wrap>.kt-inner-tab-10{display:block}.kt-tabs-wrap.kt-active-tab-11>.kt-tabs-content-wrap>.kt-inner-tab-11{display:block}.kt-tabs-wrap.kt-active-tab-12>.kt-tabs-content-wrap>.kt-inner-tab-12{display:block}.kt-tabs-wrap.kt-active-tab-13>.kt-tabs-content-wrap>.kt-inner-tab-13{display:block}.kt-tabs-wrap.kt-active-tab-14>.kt-tabs-content-wrap>.kt-inner-tab-14{display:block}.kt-tabs-wrap.kt-active-tab-15>.kt-tabs-content-wrap>.kt-inner-tab-15{display:block}.kt-tabs-wrap.kt-active-tab-16>.kt-tabs-content-wrap>.kt-inner-tab-16{display:block}.kt-tabs-wrap.kt-active-tab-17>.kt-tabs-content-wrap>.kt-inner-tab-17{display:block}.kt-tabs-wrap.kt-active-tab-18>.kt-tabs-content-wrap>.kt-inner-tab-18{display:block}.kt-tabs-wrap.kt-active-tab-19>.kt-tabs-content-wrap>.kt-inner-tab-19{display:block}.kt-tabs-wrap.kt-active-tab-20>.kt-tabs-content-wrap>.kt-inner-tab-20{display:block}.kt-tabs-wrap.kt-active-tab-21>.kt-tabs-content-wrap>.kt-inner-tab-21{display:block}.kt-tabs-wrap.kt-active-tab-22>.kt-tabs-content-wrap>.kt-inner-tab-22{display:block}.kt-tabs-wrap.kt-active-tab-23>.kt-tabs-content-wrap>.kt-inner-tab-23{display:block}.kt-tabs-wrap.kt-active-tab-24>.kt-tabs-content-wrap>.kt-inner-tab-24{display:block}.kb-tab-titles-wrap{display:-ms-inline-flexbox;display:inline-flex;-ms-flex-direction:column;flex-direction:column}.kt-title-sub-text{font-size:14px;line-height:24px}.kt-tabs-layout-vtabs:after,.kt-tabs-wrap:after{clear:both;display:table;content:''}.kt-tabs-layout-vtabs>.kt-tabs-title-list{float:left;width:30%;-ms-flex-direction:column;flex-direction:column}.kt-tabs-layout-vtabs>.kt-tabs-title-list li{margin:0 -1px 4px 0}.kt-tabs-layout-vtabs>.kt-tabs-title-list li .kt-tab-title{border-width:1px 0px 1px 1px;border-top-left-radius:0;border-top-right-radius:0}.kt-tabs-layout-vtabs>.kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-align:start;align-items:flex-start}.kt-tabs-layout-vtabs>.kt-tabs-content-wrap{float:left;width:70%}.kt-tabs-layout-vtabs.kt-tab-alignment-left>.kt-tabs-title-list li .kt-tab-title{-ms-flex-align:center;align-items:center;-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-title-list li{text-align:center}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:center;justify-content:center;-ms-flex-align:center;align-items:center}.kt-tabs-layout-vtabs.kt-tab-alignment-center>.kt-tabs-title-list li .kb-tab-titles-wrap{-ms-flex-align:center;align-items:center}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-title-list li{text-align:right}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:end;justify-content:flex-end;-ms-flex-align:center;align-items:center}.kt-tabs-layout-vtabs.kt-tab-alignment-right>.kt-tabs-title-list li .kb-tab-titles-wrap{-ms-flex-align:end;align-items:flex-end}.kt-tabs-svg-show-only .kt-button-text,.kt-tabs-svg-show-only .kb-tab-titles-wrap{display:none}.kt-tabs-accordion-title a{padding:8px 16px;display:-ms-flexbox;display:flex;color:#444;-ms-flex-align:center;align-items:center;border-style:solid;border-color:transparent;border-width:1px 1px 0 1px}.kt-tabs-accordion-title a.kt-tab-title-active{background-color:#fff;border-color:#dee2e6}.wp-block-kadence-tabs .kt-tabs-content-wrap .kt-tabs-accordion-title .kt-tab-title{border-radius:0}.kt-tabs-svg-show-only .kt-title-text{display:none}.kt-title-svg-side-left{padding-right:5px}.kt-title-svg-side-right{padding-left:5px}.kt-tabs-svg-show-only .kt-title-svg-side-right{padding-left:0px}.kt-tabs-svg-show-only .kt-title-svg-side-left{padding-right:0px}.kt-tabs-accordion-title{display:none}@media (min-width: 767px) and (max-width: 1024px){.kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list{float:none;width:100%;-ms-flex-direction:row;flex-direction:row}.kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li{margin:0 4px -1px 0}.kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li .kt-tab-title{border-width:1px 1px 0px 1px;border-top-left-radius:4px;border-top-right-radius:4px}.kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-align:center;align-items:center}.kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-content-wrap{float:none;width:100%}.kt-tabs-tablet-layout-accordion>.kt-tabs-title-list{display:none}.kt-tabs-tablet-layout-accordion>.kt-tabs-content-wrap>.kt-tabs-accordion-title{display:block}.kt-tabs-tablet-layout-accordion>.kt-tabs-content-wrap{float:none;width:100%}.kt-tabs-tablet-layout-vtabs .kt-tabs-title-list{float:left;width:30%;-ms-flex-direction:column;flex-direction:column}.kt-tabs-tablet-layout-vtabs .kt-tabs-title-list li{margin:0 -1px 4px 0}.kt-tabs-tablet-layout-vtabs .kt-tabs-title-list li .kt-tab-title{border-width:1px 0px 1px 1px;border-top-left-radius:0;border-top-right-radius:0}.kt-tabs-tablet-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-align:start;align-items:flex-start}.kt-tabs-tablet-layout-vtabs .kt-tabs-content-wrap{float:left;width:70%}.kt-tabs-tablet-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-tablet-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li{text-align:center}.kt-tabs-tablet-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:center;justify-content:center}.kt-tabs-tablet-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-tablet-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li{text-align:right}.kt-tabs-tablet-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:end;justify-content:flex-end}}@media (max-width: 767px){.kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list{float:none;width:100%;-ms-flex-direction:row;flex-direction:row}.kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li{margin:0 4px -1px 0}.kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li .kt-tab-title{border-width:1px 1px 0px 1px;border-top-left-radius:4px;border-top-right-radius:4px}.kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-align:center;align-items:center}.kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-content-wrap{float:none;width:100%}.kt-tabs-mobile-layout-accordion>.kt-tabs-title-list{display:none}.kt-tabs-mobile-layout-accordion>.kt-tabs-content-wrap>.kt-tabs-accordion-title{display:block}.kt-tabs-mobile-layout-accordion>.kt-tabs-content-wrap{float:none;width:100%}.kt-tabs-mobile-layout-vtabs .kt-tabs-title-list{float:left;width:30%;-ms-flex-direction:column;flex-direction:column}.kt-tabs-mobile-layout-vtabs .kt-tabs-title-list li{margin:0 -1px 4px 0}.kt-tabs-mobile-layout-vtabs .kt-tabs-title-list li .kt-tab-title{border-width:1px 0px 1px 1px;border-top-left-radius:0;border-top-right-radius:0}.kt-tabs-mobile-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title{-ms-flex-align:start;align-items:flex-start}.kt-tabs-mobile-layout-vtabs .kt-tabs-content-wrap{float:left;width:70%}.kt-tabs-mobile-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-mobile-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li{text-align:center}.kt-tabs-mobile-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:center;justify-content:center}.kt-tabs-mobile-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list{-ms-flex-pack:start;justify-content:flex-start}.kt-tabs-mobile-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li{text-align:right}.kt-tabs-mobile-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li .kt-tab-title{-ms-flex-pack:end;justify-content:flex-end}}ul.kt-tabs-title-list.kb-tab-title-columns-8>li{-ms-flex:0 1 12.5%;flex:0 1 12.5%}ul.kt-tabs-title-list.kb-tab-title-columns-7>li{-ms-flex:0 1 14.28%;flex:0 1 14.28%}ul.kt-tabs-title-list.kb-tab-title-columns-6>li{-ms-flex:0 1 16.67%;flex:0 1 16.67%}ul.kt-tabs-title-list.kb-tab-title-columns-5>li{-ms-flex:0 1 20%;flex:0 1 20%}ul.kt-tabs-title-list.kb-tab-title-columns-4>li{-ms-flex:0 1 25%;flex:0 1 25%}ul.kt-tabs-title-list.kb-tab-title-columns-3>li{-ms-flex:0 1 33.33%;flex:0 1 33.33%}ul.kt-tabs-title-list.kb-tab-title-columns-2>li{-ms-flex:0 1 50%;flex:0 1 50%}ul.kt-tabs-title-list.kb-tab-title-columns-1>li{-ms-flex:0 1 100%;flex:0 1 100%}ul.kt-tabs-title-list.kb-tab-title-columns-1>li>.kt-tab-title{margin-right:0px !important}ul.kt-tabs-title-list.kb-tabs-list-columns>li:last-child>.kt-tab-title{margin-right:0px !important}ul.kt-tabs-title-list.kb-tabs-list-columns .kt-tab-title{-ms-flex-pack:center;justify-content:center;text-align:center}ul.kt-tabs-title-list.kb-tabs-list-columns{word-break:break-word}.kt-tab-alignment-center ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap{-ms-flex-align:center;align-items:center}.kt-tab-alignment-right ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap{-ms-flex-align:end;align-items:flex-end}
-.kadence-info-box-image-intrisic{height:0}.kt-info-halign-center{text-align:center}.kt-info-halign-center .kadence-info-box-image-inner-intrisic-container{margin:0 auto}.kt-info-halign-right{text-align:right}.kt-info-halign-right .kadence-info-box-image-inner-intrisic-container{margin:0 0 0 auto}.kt-info-halign-left{text-align:left}.kt-info-halign-left .kadence-info-box-image-inner-intrisic-container{margin:0 auto 0 0}.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media{display:inline-block;max-width:100%}.kt-blocks-info-box-media-align-top .kt-infobox-textcontent{display:block}.kt-blocks-info-box-text{color:#555555}.wp-block-kadence-infobox .kt-blocks-info-box-text{margin-bottom:0}.kt-blocks-info-box-link-wrap:hover{background:#f2f2f2;border-color:#eeeeee}.kt-blocks-info-box-media,.kt-blocks-info-box-link-wrap{border:0 solid transparent;-webkit-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);-o-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95)}.kt-blocks-info-box-title,.kt-blocks-info-box-text,.kt-blocks-info-box-learnmore,.kt-info-svg-image{-webkit-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);-o-transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);transition:all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95)}.kt-blocks-info-box-media{border-color:#444444;color:#444444;padding:10px;margin:0 15px 0 15px}.kt-blocks-info-box-media img{padding:0;margin:0}.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media{margin:0}.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media-container{margin:0 15px 0 15px}.kt-blocks-info-box-link-wrap:hover .kt-blocks-info-box-media{border-color:#444444}.kt-blocks-info-box-link-wrap{display:block;background:#f2f2f2;padding:20px;border-color:#eeeeee}.kt-blocks-info-box-learnmore{border:0 solid transparent;display:block}.wp-block-kadence-infobox .kt-blocks-info-box-learnmore-wrap{display:inline-block;width:auto}.kt-blocks-info-box-media-align-left{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:start;justify-content:flex-start}.kt-blocks-info-box-media-align-right{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:start;justify-content:flex-start;-ms-flex-direction:row-reverse;flex-direction:row-reverse}.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-top,.kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-top{-ms-flex-align:start;align-items:flex-start}.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-bottom,.kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-bottom{-ms-flex-align:end;align-items:flex-end}.kt-blocks-info-box-media .kt-info-box-image,.kt-blocks-info-box-media-container{max-width:100%}.kadence-info-box-image-intrisic.kb-info-box-image-type-svg{height:auto;padding-bottom:0}.kt-info-animate-grayscale img,.kt-info-animate-grayscale-border-draw img{-webkit-filter:grayscale(100%);filter:grayscale(100%);-webkit-transition:0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);-o-transition:0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);transition:0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95)}.kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale img,.kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale-border-draw img{-webkit-filter:grayscale(0);filter:grayscale(0)}.kt-info-animate-flip,.kt-info-icon-animate-flip{-webkit-perspective:1000;perspective:1000}.kt-blocks-info-box-link-wrap:hover .kt-info-animate-flip .kadence-info-box-image-inner-intrisic,.kt-blocks-info-box-link-wrap:hover .kt-info-icon-animate-flip .kadence-info-box-icon-inner-container{-webkit-transform:rotateY(180deg);transform:rotateY(180deg)}.kt-info-animate-flip .kadence-info-box-image-inner-intrisic,.kt-info-icon-animate-flip .kadence-info-box-icon-inner-container{-webkit-transition:0.6s;-o-transition:0.6s;transition:0.6s;-webkit-transform-style:preserve-3d;transform-style:preserve-3d;position:relative}.kt-info-animate-flip .kt-info-box-image-flip,.kt-info-icon-animate-flip .kt-info-svg-icon-flip{-webkit-backface-visibility:hidden;backface-visibility:hidden;position:absolute;top:0;left:0}.kt-info-animate-flip .kt-info-box-image,.kt-info-icon-animate-flip .kt-info-svg-icon{-webkit-backface-visibility:hidden;backface-visibility:hidden}.kt-info-animate-flip .kt-info-box-image,.kt-info-icon-animate-flip .kt-info-svg-icon{z-index:2}.kt-info-animate-flip .kt-info-box-image-flip,.kt-info-icon-animate-flip .kt-info-svg-icon-flip{-webkit-transform:rotateY(180deg);transform:rotateY(180deg)}.kt-info-media-animate-drawborder,.kt-info-media-animate-grayscale-border-draw{position:relative;-webkit-box-sizing:border-box;box-sizing:border-box}.kt-info-media-animate-drawborder::before,.kt-info-media-animate-drawborder::after,.kt-info-media-animate-grayscale-border-draw::before,.kt-info-media-animate-grayscale-border-draw::after{-webkit-box-sizing:border-box;box-sizing:border-box;content:'';position:absolute;border:0px solid transparent;width:0;height:0}.kt-info-media-animate-drawborder::before,.kt-info-media-animate-drawborder::after,.kt-info-media-animate-grayscale-border-draw::before,.kt-info-media-animate-grayscale-border-draw::after{top:0;left:0}.kt-info-media-animate-drawborder:after,.kt-info-media-animate-grayscale-border-draw:after{-webkit-transform:rotate(-90deg);-ms-transform:rotate(-90deg);transform:rotate(-90deg)}.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:before,.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:before{width:100%;height:100%;-webkit-transition:border-top-color 0.15s linear,border-right-color 0.15s linear 0.1s,border-bottom-color 0.15s linear 0.2s;-o-transition:border-top-color 0.15s linear,border-right-color 0.15s linear 0.1s,border-bottom-color 0.15s linear 0.2s;transition:border-top-color 0.15s linear,border-right-color 0.15s linear 0.1s,border-bottom-color 0.15s linear 0.2s}.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:after,.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:after{width:100%;height:100%;-webkit-transform:rotate(180deg);-ms-transform:rotate(180deg);transform:rotate(180deg);-webkit-transition:border-bottom-width 0s linear 0.35s,-webkit-transform 0.4s linear 0s;transition:border-bottom-width 0s linear 0.35s,-webkit-transform 0.4s linear 0s;-o-transition:transform 0.4s linear 0s,border-bottom-width 0s linear 0.35s;transition:transform 0.4s linear 0s,border-bottom-width 0s linear 0.35s;transition:transform 0.4s linear 0s,border-bottom-width 0s linear 0.35s,-webkit-transform 0.4s linear 0s}
-.kt-accordion-wrap .kt-accordion-header-wrap{margin:0;padding:0}.kt-blocks-accordion-header{-ms-flex-line-pack:justify;align-content:space-between;-ms-flex-align:center;align-items:center;background-color:#f2f2f2;border:0 solid transparent;border-radius:0px;color:#555555;display:-ms-flexbox;display:flex;font-size:18px;padding:10px 14px;position:relative;line-height:24px;text-align:left;-webkit-transition:all ease-in-out .2s;-o-transition:all ease-in-out .2s;transition:all ease-in-out .2s;width:100%;-webkit-box-shadow:none;box-shadow:none;text-shadow:none}.kt-blocks-accordion-header:focus{-webkit-box-shadow:none;box-shadow:none;text-shadow:none}.kt-blocks-accordion-header:hover{background-color:#eeeeee;color:#444444;-webkit-box-shadow:none;box-shadow:none;text-shadow:none}.kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after,.kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before{background-color:#444444}.kt-blocks-accordion-header.kt-accordion-panel-active{background-color:#444444;color:#ffffff}.kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before{background-color:#ffffff}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger{background-color:#444444}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before{background-color:#eeeeee}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger{background-color:#ffffff}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before{background-color:#444444}.kt-blocks-accordion-title-wrap{display:-ms-flexbox;display:flex;padding-right:10px}.kt-accodion-icon-side-left .kt-blocks-accordion-title-wrap{padding-right:0px}.kt-pane-header-alignment-center button.kt-blocks-accordion-header{text-align:center}.kt-pane-header-alignment-center button.kt-blocks-accordion-header .kt-blocks-accordion-title-wrap{-ms-flex-positive:2;flex-grow:2;-ms-flex-pack:center;justify-content:center}.kt-pane-header-alignment-right button.kt-blocks-accordion-header{text-align:right}.kt-pane-header-alignment-right button.kt-blocks-accordion-header .kt-blocks-accordion-title-wrap{-ms-flex-positive:2;flex-grow:2;-ms-flex-pack:end;justify-content:flex-end}.kt-pane-header-alignment-right button.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger{margin-left:10px}.kt-acccordion-button-label-hide .kt-blocks-accordion-title{display:none}.kt-accordion-panel-inner:after{clear:both;display:table;content:''}.kt-accodion-icon-style-none .kt-blocks-accordion-icon-trigger{display:none}.kt-accodion-icon-side-left .kt-blocks-accordion-icon-trigger{-ms-flex-order:-1;order:-1;margin-left:0;margin-right:10px}.kt-blocks-accordion-icon-trigger{display:block;height:24px;margin-left:auto;position:relative;-webkit-transition:all ease-in-out 0.2s;-o-transition:all ease-in-out 0.2s;transition:all ease-in-out 0.2s;width:24px;min-width:24px;-webkit-box-sizing:content-box;box-sizing:content-box}.kt-blocks-accordion-icon-trigger:after,.kt-blocks-accordion-icon-trigger:before{background-color:#333}.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before{content:"";height:4px;position:absolute;-webkit-transition:all ease-in-out 0.1333333333s;-o-transition:all ease-in-out 0.1333333333s;transition:all ease-in-out 0.1333333333s;width:20px;left:2px;top:10px}.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(90deg);-ms-transform:rotate(90deg);transform:rotate(90deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger{background-color:#333;border-radius:50%}.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before{background-color:#fff;width:16px;left:4px;top:10px}.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg)}.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg)}.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before{content:"";height:4px;position:absolute;-webkit-transition:all ease-in-out 0.1333333333s;-o-transition:all ease-in-out 0.1333333333s;transition:all ease-in-out 0.1333333333s;width:20px;left:2px;top:10px}.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(90deg);-ms-transform:rotate(90deg);transform:rotate(90deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger{background-color:#333;border-radius:50%}.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before{background-color:#fff;width:16px;left:4px;top:10px}.kt-accodion-icon-style-arrow .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg)}.kt-accodion-icon-style-arrow .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg)}.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{content:"";height:2px;position:absolute;top:11px;-webkit-transition:all ease-in-out 0.1333333333s;-o-transition:all ease-in-out 0.1333333333s;transition:all ease-in-out 0.1333333333s;width:12px}.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{left:2px;-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg);-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after{-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg);right:2px;-webkit-transform-origin:50%;-ms-transform-origin:50%;transform-origin:50%}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger{background-color:#333;border-radius:50%}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after,.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{background-color:#fff;width:10px}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before{left:4px}.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after{right:4px}.kt-accordion-header-wrap{margin-top:8px}.kt-accordion-inner-wrap .wp-block-kadence-pane:first-child .kt-accordion-header-wrap{margin-top:0px}.kt-accordion-panel-inner{padding:20px;border:1px solid #eee;border-top:0}.kt-accordion-panel{overflow:auto;display:block}.kt-accordion-panel.kt-accordion-panel-hidden{max-height:0 !important;overflow:hidden;display:none}.kt-accordion-initialized .kt-panel-is-collapsing,.kt-accordion-initialized .kt-panel-is-expanding{-webkit-transition:height 0.45s ease;-o-transition:height 0.45s ease;transition:height 0.45s ease;position:relative;height:0;overflow:hidden}
-.wp-block-kadence-iconlist ul.kt-svg-icon-list{padding:0;list-style:none;margin:0 0 10px 0}.wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;padding:0;margin:0 0 5px 0}.wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap .kt-svg-icon-list-single{margin-right:10px;padding:4px 0;display:inline-block !important}.wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap .kt-svg-icon-link{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center}.wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap:last-child{margin-bottom:0}.wp-block-kadence-iconlist.kt-list-icon-aligntop ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap{-ms-flex-align:start;align-items:flex-start}.wp-block-kadence-iconlist.kt-list-icon-alignbottom ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap{-ms-flex-align:end;align-items:flex-end}.wp-block-kadence-iconlist.aligncenter .kt-svg-icon-list-item-wrap{-ms-flex-pack:center;justify-content:center}.kt-svg-icon-list-style-stacked .kt-svg-icon-list-single{border:0px solid transparent}.kt-svg-icon-list-columns-2 ul.kt-svg-icon-list{grid-template-columns:50% auto;grid-template-rows:auto;display:grid}.kt-svg-icon-list-columns-3 ul.kt-svg-icon-list{grid-template-columns:33% 33% auto;grid-template-rows:auto;display:grid}.kt-info-icon-animate-flip .kadence-info-box-icon-inner-container{-webkit-backface-visibility:hidden;backface-visibility:hidden}
-.wp-block-kadence-testimonials .kt-blocks-carousel{padding-bottom:35px;margin-left:-15px;margin-right:-15px}.wp-block-kadence-testimonials .kt-blocks-carousel.kt-carousel-container-dotstyle-none{padding-bottom:0}.wp-block-kadence-testimonials .kt-blocks-carousel .kt-blocks-carousel-init:not(.kt-carousel-arrowstyle-none){padding-left:35px;padding-right:35px}.wp-block-kadence-testimonials .kt-blocks-carousel .kt-blocks-testimonial-carousel-item{padding:0 15px}.kt-testimonial-grid-wrap{display:-ms-grid;display:grid;-ms-grid-columns:1fr 1fr;grid-template-columns:1fr 1fr;grid-template-rows:1fr;grid-gap:30px 30px}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap{margin:0 30px 30px 0;width:auto}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:last-child{margin-right:0}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(1){-ms-grid-column:1}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(2){-ms-grid-column:2}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(3){-ms-grid-column:3}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(4){-ms-grid-column:4}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(5){-ms-grid-column:5}@supports (grid-gap: 30px 30px){.kt-testimonial-grid-wrap .kt-testimonial-item-wrap{margin:0 auto;width:100%}.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:last-child{margin-right:auto}}.kt-testimonial-columns-1 .kt-testimonial-grid-wrap{display:block}.kt-testimonial-columns-3 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr}.kt-testimonial-columns-4 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr}.kt-testimonial-columns-5 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr 1fr}@media (min-width: 1200px) and (max-width: 1499px){.kt-t-xl-col-1 .kt-testimonial-grid-wrap{display:block}.kt-t-xl-col-2 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr;grid-template-columns:1fr 1fr}.kt-t-xl-col-3 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr}.kt-t-xl-col-4 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr}.kt-t-xl-col-5 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr 1fr}}@media (min-width: 992px) and (max-width: 1199px){.kt-t-lg-col-1 .kt-testimonial-grid-wrap{display:block}.kt-t-lg-col-2 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr;grid-template-columns:1fr 1fr}.kt-t-lg-col-3 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr}.kt-t-lg-col-4 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr}.kt-t-lg-col-5 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr 1fr}}@media (min-width: 768px) and (max-width: 991px){.kt-t-md-col-1 .kt-testimonial-grid-wrap{display:block}.kt-t-md-col-2 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr;grid-template-columns:1fr 1fr}.kt-t-md-col-3 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr}.kt-t-md-col-4 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr}.kt-t-md-col-5 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr 1fr}}@media (min-width: 544px) and (max-width: 767px){.kt-t-sm-col-1 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr;display:block}.kt-t-sm-col-2 .kt-testimonial-grid-wrap{grid-template-columns:1fr 1fr}.kt-t-sm-col-3 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr}.kt-t-sm-col-4 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr}.kt-t-sm-col-5 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr 1fr}}@media (max-width: 543px){.kt-t-xs-col-1 .kt-testimonial-grid-wrap{display:block}.kt-t-xs-col-2 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr;grid-template-columns:1fr 1fr}.kt-t-xs-col-3 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr}.kt-t-xs-col-4 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr}.kt-t-xs-col-5 .kt-testimonial-grid-wrap{-ms-grid-columns:1fr 1fr 1fr 1fr 1fr;grid-template-columns:1fr 1fr 1fr 1fr 1fr}}.kt-testimonial-media-inner-wrap{overflow:hidden;border:0 solid transparent;width:60px;margin:0 15px 0 0;border-radius:100%}.kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic{padding-bottom:100%;height:0;position:relative}.kt-testimonial-media-inner-wrap .kt-testimonial-image{background-position:center;background-repeat:no-repeat;background-size:cover;width:100%;height:100%;position:absolute;left:0;padding:0;border-radius:100%}.kt-testimonial-media-inner-wrap .kt-svg-testimonial-icon{position:absolute;width:100%;height:100%}.kt-testimonial-item-wrap{border:0 solid transparent;max-width:500px;text-align:center;margin:0 auto}.kt-testimonial-meta-wrap{display:-ms-flexbox;display:flex;-ms-flex-pack:center;justify-content:center;-ms-flex-align:center;align-items:center;margin-top:10px}.kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:left}.kt-svg-testimonial-global-icon{border:2px solid #eeeeee;border-radius:100%;background:transparent;color:#444444;padding:20px}.kt-svg-testimonial-global-icon-wrap{margin:0 0 10px 0}.kt-testimonial-style-card .kt-testimonial-media-inner-wrap{width:auto;margin:0 0 15px 0;border-radius:0}.kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic{padding-bottom:50%}.kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kt-testimonial-image{border-radius:0}.kt-testimonial-style-card .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:center}.kt-testimonial-style-card.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap{margin:0 0 15px 0}.kt-testimonial-style-bubble .kt-testimonial-text-wrap{border:2px solid #eee;padding:20px;position:relative;border-radius:10px}.kt-testimonial-style-bubble .kt-testimonial-text-wrap:after{height:0;left:50%;top:100%;position:absolute;border-top:14px solid #eee;border-bottom:14px solid transparent;border-left:14px solid transparent;border-right:14px solid transparent;content:'';-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%);width:0}.kt-testimonial-style-bubble .kt-testimonial-meta-wrap{margin-top:20px}.kt-testimonial-style-bubble.kt-testimonial-halign-left .kt-testimonial-meta-wrap{margin-left:6px}.kt-testimonial-style-bubble.kt-testimonial-halign-left.kt-testimonials-media-off .kt-testimonial-meta-wrap{margin-left:20px}.kt-testimonial-style-bubble.kt-testimonial-halign-right .kt-testimonial-meta-wrap{margin-right:6px}.kt-testimonial-style-bubble.kt-testimonial-halign-right.kt-testimonials-media-off .kt-testimonial-meta-wrap{margin-right:20px}.kt-testimonial-style-bubble .kt-svg-testimonial-global-icon{background:#fff}.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap{margin:-55px 0 10px 0}.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-testimonial-item-wrap{padding-top:55px}.kt-testimonial-halign-center.kt-testimonial-media-off .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:center}.kt-testimonial-style-inlineimage .kt-testimonial-media-wrap{float:left}.kt-testimonial-style-inlineimage .kt-testimonial-text-wrap{border:2px solid #eee;padding:20px;position:relative;border-radius:10px;text-align:left}.kt-testimonial-style-inlineimage .kt-testimonial-text-wrap:after{height:0;left:20px;top:100%;position:absolute;border-top:14px solid #eee;border-bottom:14px solid transparent;border-left:14px solid transparent;border-right:14px solid transparent;content:'';-webkit-transform:none;-ms-transform:none;transform:none;width:0}.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap{margin-top:2px;-ms-flex-pack:start;justify-content:flex-start;padding-left:60px}.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap{text-align:left;display:-ms-flexbox;display:flex}.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap .kt-testimonial-name-wrap{padding-right:6px}.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-text-wrap{text-align:left}.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-media-wrap{float:right}.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-meta-wrap{padding-left:0px;padding-right:60px}.kt-testimonial-style-inlineimage .kt-svg-testimonial-global-icon{background:#fff}.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap{margin:-55px 0 10px 0}.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-testimonial-item-wrap{padding-top:55px}.kt-testimonial-halign-left .kt-testimonial-item-wrap{text-align:left;margin:0}.kt-testimonial-halign-left .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap{text-align:left}.kt-testimonial-halign-left .kt-testimonial-meta-wrap{-ms-flex-pack:start;justify-content:flex-start}.kt-testimonial-halign-left .kt-testimonial-text-wrap:after{left:20px;-webkit-transform:none;-ms-transform:none;transform:none}.kt-testimonial-halign-right .kt-testimonial-item-wrap{text-align:right;margin-left:auto;margin-right:0}.kt-testimonial-halign-right .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap{text-align:right}.kt-testimonial-halign-right .kt-testimonial-meta-wrap{-ms-flex-pack:start;justify-content:flex-start;-ms-flex-direction:row-reverse;flex-direction:row-reverse}.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap{margin:0 0 0 15px}.kt-testimonial-halign-right .kt-testimonial-text-wrap:after{left:auto;right:20px;-webkit-transform:none;-ms-transform:none;transform:none}.kt-testimonial-name a{color:inherit}.kt-testimonial-occupation a{color:inherit}
-.kb-gallery-ul *{-webkit-box-sizing:border-box;box-sizing:border-box}.wp-block-kadence-advancedgallery{overflow:hidden}.wp-block-kadence-advancedgallery:after{clear:both;display:table;content:''}.kb-gallery-ul{display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;list-style-type:none;padding:0;-webkit-box-sizing:border-box;box-sizing:border-box;margin:-5px}.kb-gallery-ul .kadence-blocks-gallery-item{position:relative;padding:5px;list-style-type:none;margin:0;-webkit-box-sizing:border-box;box-sizing:border-box}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner{position:relative;margin-bottom:0}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure{margin:0}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gal-image-radius{position:relative;overflow:hidden;z-index:1;margin:0 auto}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain{border:0;background:transparent;padding:0;margin:0;display:block;width:100%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic{height:0;position:relative}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic img{position:absolute;-ms-flex:1;flex:1;height:100%;-o-object-fit:cover;object-fit:cover;width:100%;top:0;left:0}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-square{padding-bottom:100%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land43{padding-bottom:75%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land32{padding-bottom:66.67%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land21{padding-bottom:50%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land31{padding-bottom:33%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land41{padding-bottom:25%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port34{padding-bottom:133.33%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port23{padding-bottom:150%}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img{display:block;max-width:100%;height:auto;width:100%;margin:0;padding:0}@supports ((position: -webkit-sticky) or (position: sticky)){.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img{width:auto}}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption{position:absolute;bottom:0;max-height:100%;overflow-y:auto;width:100%;max-height:100%;overflow-y:auto;padding:43px 10px 10px;font-size:13px;margin-top:0;color:#f4f4f4;text-align:center;background:-webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(41,41,41,0.5)), to(rgba(41,41,41,0)));background:-webkit-linear-gradient(bottom, rgba(41,41,41,0.5) 0, rgba(41,41,41,0) 100%);background:-o-linear-gradient(bottom, rgba(41,41,41,0.5) 0, rgba(41,41,41,0) 100%);background:linear-gradient(0deg, rgba(41,41,41,0.5) 0, rgba(41,41,41,0) 100%)}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption img{display:inline}.kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kadence-blocks-gallery-item-hide-caption figcaption{display:none}.kb-gallery-ul[data-columns-xs="1"] .kadence-blocks-gallery-item{width:100%}.kb-gallery-ul[data-columns-xs="2"] .kadence-blocks-gallery-item{width:50%}.kb-gallery-ul[data-columns-xs="3"] .kadence-blocks-gallery-item{width:33.33333%}.kb-gallery-ul[data-columns-xs="4"] .kadence-blocks-gallery-item{width:25%}.kb-gallery-ul[data-columns-xs="5"] .kadence-blocks-gallery-item{width:20%}.kb-gallery-ul[data-columns-xs="6"] .kadence-blocks-gallery-item{width:16.66667%}.kb-gallery-ul[data-columns-xs="7"] .kadence-blocks-gallery-item{width:14.28571%}.kb-gallery-ul[data-columns-xs="8"] .kadence-blocks-gallery-item{width:12.5%}@media (min-width: 543px){.kb-gallery-ul[data-columns-sm="1"] .kadence-blocks-gallery-item{width:100%}.kb-gallery-ul[data-columns-sm="2"] .kadence-blocks-gallery-item{width:50%}.kb-gallery-ul[data-columns-sm="3"] .kadence-blocks-gallery-item{width:33.33333%}.kb-gallery-ul[data-columns-sm="4"] .kadence-blocks-gallery-item{width:25%}.kb-gallery-ul[data-columns-sm="5"] .kadence-blocks-gallery-item{width:20%}.kb-gallery-ul[data-columns-sm="6"] .kadence-blocks-gallery-item{width:16.66667%}.kb-gallery-ul[data-columns-sm="7"] .kadence-blocks-gallery-item{width:14.28571%}.kb-gallery-ul[data-columns-sm="8"] .kadence-blocks-gallery-item{width:12.5%}}@media (min-width: 768px){.kb-gallery-ul[data-columns-md="1"] .kadence-blocks-gallery-item{width:100%}.kb-gallery-ul[data-columns-md="2"] .kadence-blocks-gallery-item{width:50%}.kb-gallery-ul[data-columns-md="3"] .kadence-blocks-gallery-item{width:33.33333%}.kb-gallery-ul[data-columns-md="4"] .kadence-blocks-gallery-item{width:25%}.kb-gallery-ul[data-columns-md="5"] .kadence-blocks-gallery-item{width:20%}.kb-gallery-ul[data-columns-md="6"] .kadence-blocks-gallery-item{width:16.66667%}.kb-gallery-ul[data-columns-md="7"] .kadence-blocks-gallery-item{width:14.28571%}.kb-gallery-ul[data-columns-md="8"] .kadence-blocks-gallery-item{width:12.5%}}@media (min-width: 992px){.kb-gallery-ul[data-columns-lg="1"] .kadence-blocks-gallery-item{width:100%}.kb-gallery-ul[data-columns-lg="2"] .kadence-blocks-gallery-item{width:50%}.kb-gallery-ul[data-columns-lg="3"] .kadence-blocks-gallery-item{width:33.33333%}.kb-gallery-ul[data-columns-lg="4"] .kadence-blocks-gallery-item{width:25%}.kb-gallery-ul[data-columns-lg="5"] .kadence-blocks-gallery-item{width:20%}.kb-gallery-ul[data-columns-lg="6"] .kadence-blocks-gallery-item{width:16.66667%}.kb-gallery-ul[data-columns-lg="7"] .kadence-blocks-gallery-item{width:14.28571%}.kb-gallery-ul[data-columns-lg="8"] .kadence-blocks-gallery-item{width:12.5%}}@media (min-width: 1200px){.kb-gallery-ul[data-columns-xl="1"] .kadence-blocks-gallery-item{width:100%}.kb-gallery-ul[data-columns-xl="2"] .kadence-blocks-gallery-item{width:50%}.kb-gallery-ul[data-columns-xl="3"] .kadence-blocks-gallery-item{width:33.33333%}.kb-gallery-ul[data-columns-xl="4"] .kadence-blocks-gallery-item{width:25%}.kb-gallery-ul[data-columns-xl="5"] .kadence-blocks-gallery-item{width:20%}.kb-gallery-ul[data-columns-xl="6"] .kadence-blocks-gallery-item{width:16.66667%}.kb-gallery-ul[data-columns-xl="7"] .kadence-blocks-gallery-item{width:14.28571%}.kb-gallery-ul[data-columns-xl="8"] .kadence-blocks-gallery-item{width:12.5%}}@media (min-width: 1500px){.kb-gallery-ul[data-columns-xxl="1"] .kadence-blocks-gallery-item{width:100%}.kb-gallery-ul[data-columns-xxl="2"] .kadence-blocks-gallery-item{width:50%}.kb-gallery-ul[data-columns-xxl="3"] .kadence-blocks-gallery-item{width:33.33333%}.kb-gallery-ul[data-columns-xxl="4"] .kadence-blocks-gallery-item{width:25%}.kb-gallery-ul[data-columns-xxl="5"] .kadence-blocks-gallery-item{width:20%}.kb-gallery-ul[data-columns-xxl="6"] .kadence-blocks-gallery-item{width:16.66667%}.kb-gallery-ul[data-columns-xxl="7"] .kadence-blocks-gallery-item{width:14.28571%}.kb-gallery-ul[data-columns-xxl="8"] .kadence-blocks-gallery-item{width:12.5%}}.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item figcaption{opacity:0;-webkit-transition:opacity 0.3s ease-in-out;-o-transition:opacity 0.3s ease-in-out;transition:opacity 0.3s ease-in-out}.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item:hover figcaption,.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item .is-selected figcaption{opacity:1}.kb-gallery-ul.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption{display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;position:absolute;left:0;right:0;top:0;bottom:0;padding:10px;margin:0;opacity:0;-webkit-transition:opacity 0.3s ease-in-out;-o-transition:opacity 0.3s ease-in-out;transition:opacity 0.3s ease-in-out;background:rgba(0,0,0,0.5)}.kb-gallery-ul.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item:hover figcaption{opacity:1}.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-ul.kb-gallery-type-carousel,.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-ul.kb-gallery-type-fluidcarousel,.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-ul.kb-gallery-type-slider{margin:0}.kb-gallery-ul.kb-gallery-type-carousel,.kb-gallery-ul.kb-gallery-type-slider{display:block;margin:0}.kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider,.kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-slider{margin:0 -5px;-webkit-user-select:auto;-moz-user-select:auto;-ms-user-select:auto;user-select:auto;-ms-touch-action:auto;touch-action:auto}.kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider .kb-slide-item,.kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-slider .kb-slide-item{padding:4px 5px}.kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-prev,.kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-prev{left:5px}.kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-next,.kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-next{right:5px}.kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item,.kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item{padding:0 !important}.kb-gallery-ul.kb-gallery-type-fluidcarousel{display:block;margin:0}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .kt-blocks-carousel-init{margin:0;-webkit-user-select:auto;-moz-user-select:auto;-ms-user-select:auto;user-select:auto;-ms-touch-action:auto;touch-action:auto}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .kt-blocks-carousel-init .kb-slide-item{padding:4px 5px}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .kt-blocks-carousel-init.kb-carousel-mode-align-left .kb-slide-item{padding:4px 10px 4px 0}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-prev{left:0px}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-next{right:0px}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kadence-blocks-gallery-item{padding:0 !important}.kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit{padding-bottom:100%}.kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img{-o-object-fit:contain;object-fit:contain}.kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit{padding-bottom:66.67%}.kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img{-o-object-fit:contain;object-fit:contain}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel figure .kb-gal-image-radius{height:300px;width:auto;margin:0 auto}.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel figure .kb-gal-image-radius img{height:300px;width:auto;-ms-flex:1;flex:1;-o-object-fit:cover;object-fit:cover}.kb-gallery-type-fluidcarousel.kb-gallery-caption-style-below .kb-gallery-item-link,.kb-gallery-type-fluidcarousel.kb-gallery-caption-style-below figure:not(.kb-gallery-item-has-link){display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column}.kb-gallery-caption-style-below .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption.kadence-blocks-gallery-item__caption{padding:10px;margin-top:0;background:rgba(0,0,0,0.5);position:static}.kb-gallery-type-carousel .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after,.kb-gallery-type-slider .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after{display:none}.kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item .kb-has-image-ratio-inherit .kb-gal-image-radius,.kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item .kb-has-image-ratio-inherit .kb-gal-image-radius{border-radius:0}.kb-gallery-filter-vintage .kb-gallery-image-contain:after{content:'';position:absolute;left:0;right:0;top:0;bottom:0;-webkit-box-shadow:inset 0 0 100px rgba(0,0,20,0.4),inset 0 5px 15px rgba(0,0,0,0.1);box-shadow:inset 0 0 100px rgba(0,0,20,0.4),inset 0 5px 15px rgba(0,0,0,0.1);background:-webkit-linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),-webkit-linear-gradient(70deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%);background:-o-linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),-o-linear-gradient(70deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%);background:linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),linear-gradient(20deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%)}.kb-gallery-filter-vintage .kb-gallery-image-contain img{-webkit-filter:sepia(0.2) brightness(1.1) contrast(1.3);filter:sepia(0.2) brightness(1.1) contrast(1.3)}.kb-gal-light-filter-vintage .mfp-figure figure::before{-webkit-box-shadow:inset 0 0 100px rgba(0,0,20,0.4),inset 0 5px 15px rgba(0,0,0,0.1);box-shadow:inset 0 0 100px rgba(0,0,20,0.4),inset 0 5px 15px rgba(0,0,0,0.1);background:-webkit-linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),-webkit-linear-gradient(70deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%);background:-o-linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),-o-linear-gradient(70deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%);background:linear-gradient(top, rgba(255,145,0,0.2) 0%, rgba(255,230,48,0.2) 60%),linear-gradient(20deg, rgba(255,0,0,0.2) 0%, rgba(255,0,0,0) 35%);content:'';position:absolute;left:0;right:0;top:40px;bottom:40px;z-index:1}.kb-gal-light-filter-vintage .mfp-figure figure img{-webkit-filter:sepia(0.2) brightness(1.1) contrast(1.3);filter:sepia(0.2) brightness(1.1) contrast(1.3)}.kb-gallery-filter-grayscale .kb-gallery-image-contain img,.kb-gal-light-filter-grayscale .mfp-figure img{-webkit-filter:grayscale(1);filter:grayscale(1)}.kb-gallery-filter-sepia .kb-gallery-image-contain img,.kb-gal-light-filter-sepia .mfp-figure img{-webkit-filter:sepia(0.5);filter:sepia(0.5)}.kb-gallery-filter-saturation .kb-gallery-image-contain img,.kb-gal-light-filter-saturation .mfp-figure img{-webkit-filter:saturate(1.6);filter:saturate(1.6)}.kb-gallery-filter-earlybird .kb-gallery-image-contain::after{background:-webkit-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);background:-o-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);background:radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);mix-blend-mode:overlay;content:'';position:absolute;left:0;right:0;top:0;bottom:0}.kb-gallery-filter-earlybird .kb-gallery-image-contain img{-webkit-filter:contrast(0.9) sepia(0.2);filter:contrast(0.9) sepia(0.2)}.kb-gal-light-filter-earlybird .mfp-figure figure::before{background:-webkit-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);background:-o-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);background:radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);mix-blend-mode:overlay;content:'';position:absolute;left:0;right:0;top:40px;bottom:40px;z-index:1}.kb-gal-light-filter-earlybird .mfp-figure figure img{-webkit-filter:contrast(0.9) sepia(0.2);filter:contrast(0.9) sepia(0.2)}.kb-gallery-filter-toaster .kb-gallery-image-contain::after{background:-webkit-radial-gradient(circle, #804e0f, #3b003b);background:-o-radial-gradient(circle, #804e0f, #3b003b);background:radial-gradient(circle, #804e0f, #3b003b);mix-blend-mode:screen;content:'';position:absolute;left:0;right:0;top:0;bottom:0}.kb-gallery-filter-toaster .kb-gallery-image-contain img{-webkit-filter:contrast(1.5) brightness(0.9);filter:contrast(1.5) brightness(0.9)}.kb-gal-light-filter-toaster .mfp-figure figure::before{background:-webkit-radial-gradient(circle, #804e0f, #3b003b);background:-o-radial-gradient(circle, #804e0f, #3b003b);background:radial-gradient(circle, #804e0f, #3b003b);mix-blend-mode:screen;content:'';position:absolute;left:0;right:0;top:40px;bottom:40px;z-index:1}.kb-gal-light-filter-toaster .mfp-figure figure img{-webkit-filter:contrast(1.5) brightness(0.9);filter:contrast(1.5) brightness(0.9)}.kb-gallery-filter-mayfair .kb-gallery-image-contain::after{background:-webkit-radial-gradient(40% 40%, circle, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);background:-o-radial-gradient(40% 40%, circle, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);background:radial-gradient(circle at 40% 40%, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);mix-blend-mode:overlay;opacity:.4;content:'';position:absolute;left:0;right:0;top:0;bottom:0}.kb-gallery-filter-mayfair .kb-gallery-image-contain img{-webkit-filter:contrast(1.1) saturate(1.1);filter:contrast(1.1) saturate(1.1)}.kb-gal-light-filter-mayfair .mfp-figure figure::before{background:-webkit-radial-gradient(40% 40%, circle, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);background:-o-radial-gradient(40% 40%, circle, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);background:radial-gradient(circle at 40% 40%, rgba(255,255,255,0.8), rgba(255,200,200,0.6), #111 60%);mix-blend-mode:overlay;opacity:.4;content:'';position:absolute;left:0;right:0;top:40px;bottom:40px;z-index:1}.kb-gal-light-filter-mayfair .mfp-figure figure img{-webkit-filter:contrast(1.1) saturate(1.1);filter:contrast(1.1) saturate(1.1)}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item:nth-child(-n+3){width:33.33%;display:block;float:left}.kt-blocks-carousel-init:after{clear:both;display:table;content:''}.kb-blocks-fluid-carousel:not(.slick-initialized) .kb-slide-item{max-width:80%;margin:0 auto;display:none}.kb-blocks-fluid-carousel:not(.slick-initialized) .kb-slide-item:nth-child(-n+1){display:block}.kt-blocks-carousel-init:not(.slick-initialized){margin:0 -5px}@media (max-width: 543px){.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="1"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="1"] .kb-slide-item:nth-child(-n+1){width:100%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="2"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="2"] .kb-slide-item:nth-child(-n+2){width:50%;display:block;float:left}}@media (min-width: 544px) and (max-width: 767px){.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="1"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="1"] .kb-slide-item:nth-child(-n+1){width:100%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="2"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="2"] .kb-slide-item:nth-child(-n+2){width:50%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="3"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="3"] .kb-slide-item:nth-child(-n+3){width:33.33333%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="4"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="4"] .kb-slide-item:nth-child(-n+4){width:25%;display:block;float:left}}@media (min-width: 768px) and (max-width: 991px){.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="1"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="1"] .kb-slide-item:nth-child(-n+1){width:100%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="2"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="2"] .kb-slide-item:nth-child(-n+2){width:50%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="3"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="3"] .kb-slide-item:nth-child(-n+3){width:33.33333%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="4"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="4"] .kb-slide-item:nth-child(-n+4){width:25%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="5"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="5"] .kb-slide-item:nth-child(-n+5){width:20%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="6"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="6"] .kb-slide-item:nth-child(-n+6){width:16.66667%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="7"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="7"] .kb-slide-item:nth-child(-n+7){width:14.28571%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="8"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="8"] .kb-slide-item:nth-child(-n+8){width:12.5%;display:block;float:left}}@media (min-width: 992px) and (max-width: 1199px){.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="1"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="1"] .kb-slide-item:nth-child(-n+1){width:100%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="2"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="2"] .kb-slide-item:nth-child(-n+2){width:50%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="3"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="3"] .kb-slide-item:nth-child(-n+3){width:33.33333%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="4"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="4"] .kb-slide-item:nth-child(-n+4){width:25%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="5"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="5"] .kb-slide-item:nth-child(-n+5){width:20%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="6"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="6"] .kb-slide-item:nth-child(-n+6){width:16.66667%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="7"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="7"] .kb-slide-item:nth-child(-n+7){width:14.28571%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="8"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="8"] .kb-slide-item:nth-child(-n+8){width:12.5%;display:block;float:left}}@media (min-width: 1200px) and (max-width: 1499px){.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="1"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="1"] .kb-slide-item:nth-child(-n+1){width:100%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="2"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="2"] .kb-slide-item:nth-child(-n+2){width:50%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="3"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="3"] .kb-slide-item:nth-child(-n+3){width:33.33333%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="4"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="4"] .kb-slide-item:nth-child(-n+4){width:25%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="5"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="5"] .kb-slide-item:nth-child(-n+5){width:20%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="6"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="6"] .kb-slide-item:nth-child(-n+6){width:16.66667%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="7"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="7"] .kb-slide-item:nth-child(-n+7){width:14.28571%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="8"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="8"] .kb-slide-item:nth-child(-n+8){width:12.5%;display:block;float:left}}@media (min-width: 1500px){.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="1"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="1"] .kb-slide-item:nth-child(-n+1){width:100%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="2"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="2"] .kb-slide-item:nth-child(-n+2){width:50%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item:nth-child(-n+3){width:33.33333%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="4"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="4"] .kb-slide-item:nth-child(-n+4){width:25%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="5"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="5"] .kb-slide-item:nth-child(-n+5){width:20%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="6"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="6"] .kb-slide-item:nth-child(-n+6){width:16.66667%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="7"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="7"] .kb-slide-item:nth-child(-n+7){width:14.28571%;display:block;float:left}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="8"] .kb-slide-item{display:none}.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="8"] .kb-slide-item:nth-child(-n+8){width:12.5%;display:block;float:left}}.kt-blocks-carousel-init:not(.slick-initialized) .kb-slide-item{padding:4px 5px}
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.kt-block-spacer {
+  position: relative;
+  height: 60px; }
+
+.kt-block-spacer .kt-divider {
+  width: 100%;
+  border-top: solid 1px #eee;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin: 0;
+  padding: 0;
+  border-bottom: 0;
+  border-left: 0;
+  border-right: 0;
+  -webkit-transform: perspective(1px) translate(-50%, -50%);
+          transform: perspective(1px) translate(-50%, -50%); }
+
+.kt-block-spacer.kt-block-spacer-halign-left .kt-divider {
+  left: 0;
+  -webkit-transform: perspective(1px) translate(0%, -50%);
+          transform: perspective(1px) translate(0%, -50%); }
+
+.kt-block-spacer.kt-block-spacer-halign-right .kt-divider {
+  left: auto;
+  right: 0;
+  -webkit-transform: perspective(1px) translate(0%, -50%);
+          transform: perspective(1px) translate(0%, -50%); }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ */
+.kt-button {
+  padding: 8px 16px;
+  z-index: 1;
+  position: relative;
+  cursor: pointer;
+  font-size: 18px;
+  display: -ms-flexbox;
+  display: flex;
+  line-height: 1.6;
+  text-decoration: none;
+  text-align: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  border-style: solid;
+  -webkit-transition: all .3s ease-in-out;
+  -o-transition: all .3s ease-in-out;
+  transition: all .3s ease-in-out;
+  border-width: 2px;
+  border-radius: 3px;
+  border-color: #555555;
+  overflow: hidden;
+  background: transparent;
+  color: #555555; }
+
+.kt-button::before {
+  position: absolute;
+  content: "";
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
+  opacity: 0;
+  background: #444444;
+  -webkit-transition: all .3s ease-in-out;
+  -o-transition: all .3s ease-in-out;
+  transition: all .3s ease-in-out; }
+
+.kt-button:hover, .kt-button:focus {
+  border-color: #444444;
+  color: #ffffff; }
+
+.kt-button:hover::before, .kt-button:focus::before {
+  opacity: 1; }
+
+.kt-btn-size-small {
+  font-size: 16px;
+  padding: 4px 8px;
+  border-width: 1px; }
+
+.kt-btn-size-large {
+  font-size: 20px;
+  padding: 12px 24px;
+  border-width: 3px; }
+
+.kt-btn-svg-icon.kt-btn-side-right {
+  padding-left: 5px; }
+
+.kt-btn-svg-icon.kt-btn-side-left {
+  padding-right: 5px; }
+
+.kt-btn-has-text-false .kt-btn-svg-icon {
+  padding-left: 0;
+  padding-right: 0; }
+
+.kt-btn-wrap {
+  display: inline-block;
+  margin-bottom: 5px; }
+
+.kt-btn-align-center {
+  text-align: center; }
+
+.kt-btn-align-left {
+  text-align: left; }
+
+.kt-btn-align-right {
+  text-align: right; }
+
+.wp-block-kadence-advancedbtn .kt-btn-wrap:last-child {
+  margin-right: 0; }
+
+.wp-block-kadence-advancedbtn .kt-btn-wrap {
+  margin-right: 5px; }
+
+.kt-force-btn-fullwidth {
+  display: -ms-flexbox;
+  display: flex; }
+
+.kt-force-btn-fullwidth .kt-btn-wrap {
+  display: block;
+  -ms-flex-positive: 1;
+      flex-grow: 1; }
+
+.kt-force-btn-fullwidth .kt-btn-wrap .kt-button {
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+@media (min-width: 768px) and (max-width: 1024px) {
+  .kt-btn-tablet-align-center {
+    text-align: center; }
+  .kt-btn-tablet-align-left {
+    text-align: left; }
+  .kt-btn-tablet-align-right {
+    text-align: right; } }
+
+@media (max-width: 767px) {
+  .kt-btn-mobile-align-center {
+    text-align: center; }
+  .kt-btn-mobile-align-left {
+    text-align: left; }
+  .kt-btn-mobile-align-right {
+    text-align: right; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.kt-row-layout-inner {
+  position: relative; }
+
+.kt-row-column-wrap {
+  padding: 25px 0 25px 0;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: nowrap;
+      flex-wrap: nowrap;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
+  position: relative;
+  z-index: 10; }
+
+.kt-row-has-bg > .kt-row-column-wrap {
+  padding-left: 15px;
+  padding-right: 15px; }
+
+.alignfull .kt-row-column-wrap {
+  padding-left: 15px;
+  padding-right: 15px; }
+
+.wp-block-kadence-column {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  z-index: 1;
+  min-width: 0;
+  min-height: 0; }
+
+.kt-inner-column-height-full > .wp-block-kadence-column > .kt-inside-inner-col {
+  height: 100%; }
+
+.wp-block-kadence-rowlayout:before {
+  clear: both;
+  content: '';
+  display: table; }
+
+.kt-row-layout-overlay {
+  top: 0;
+  left: 0;
+  position: absolute;
+  opacity: 0.3;
+  height: 100%;
+  width: 100%;
+  z-index: 0; }
+
+.kt-inside-inner-col {
+  border: 0 solid transparent;
+  -ms-flex-negative: 0; }
+
+.kt-row-valign-middle > .wp-block-kadence-column {
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-row-valign-bottom > .wp-block-kadence-column {
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+#content .entry-content .wp-block-kadence-rowlayout.alignfull, #content .entry-content .wp-block-kadence-rowlayout.alignwide {
+  text-align: inherit;
+  margin-bottom: 0; }
+
+@media (min-width: 767px) {
+  .kt-row-layout-equal > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1;
+    width: 0; }
+  .kt-row-layout-row {
+    -ms-flex-direction: column;
+        flex-direction: column; }
+    .kt-row-layout-row > .wp-block-kadence-column {
+      -ms-flex: none;
+          flex: none;
+      width: 100%;
+      margin-right: 0; }
+    .kt-row-layout-row.kt-v-gutter-default > .wp-block-kadence-column {
+      margin-bottom: 30px; }
+    .kt-row-layout-row.kt-v-gutter-skinny > .wp-block-kadence-column {
+      margin-bottom: 10px; }
+    .kt-row-layout-row.kt-v-gutter-narrow > .wp-block-kadence-column {
+      margin-bottom: 20px; }
+    .kt-row-layout-row.kt-v-gutter-wide > .wp-block-kadence-column {
+      margin-bottom: 40px; }
+    .kt-row-layout-row.kt-v-gutter-wider > .wp-block-kadence-column {
+      margin-bottom: 60px; }
+    .kt-row-layout-row.kt-v-gutter-widest > .wp-block-kadence-column {
+      margin-bottom: 80px; }
+    .kt-row-layout-row:not(.kt-v-gutter-none) > .wp-block-kadence-column:last-child {
+      margin-bottom: 0px; }
+  .kt-gutter-default > .wp-block-kadence-column {
+    margin-right: 30px; }
+  .kt-gutter-skinny > .wp-block-kadence-column {
+    margin-right: 10px; }
+  .kt-gutter-narrow > .wp-block-kadence-column {
+    margin-right: 20px; }
+  .kt-gutter-wide > .wp-block-kadence-column {
+    margin-right: 40px; }
+  .kt-gutter-wider > .wp-block-kadence-column {
+    margin-right: 60px; }
+  .kt-gutter-widest > .wp-block-kadence-column {
+    margin-right: 80px; }
+  .kt-row-column-wrap:not(.kt-gutter-none) > .wp-block-kadence-column:last-child {
+    margin-right: 0px; }
+  .kt-gutter-skinny.kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex-preferred-size: 10px;
+        flex-basis: 10px; }
+  .kt-gutter-skinny.kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex-preferred-size: 10px;
+        flex-basis: 10px; }
+  .kt-gutter-narrow.kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex-preferred-size: 20px;
+        flex-basis: 20px; }
+  .kt-gutter-narrow.kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex-preferred-size: 20px;
+        flex-basis: 20px; }
+  .kt-gutter-default.kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex-preferred-size: 30px;
+        flex-basis: 30px; }
+  .kt-gutter-default.kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex-preferred-size: 30px;
+        flex-basis: 30px; }
+  .kt-gutter-wide.kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex-preferred-size: 40px;
+        flex-basis: 40px; }
+  .kt-gutter-wide.kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex-preferred-size: 40px;
+        flex-basis: 40px; }
+  .kt-gutter-wider.kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex-preferred-size: 60px;
+        flex-basis: 60px; }
+  .kt-gutter-wider.kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex-preferred-size: 60px;
+        flex-basis: 60px; }
+  .kt-gutter-widest.kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex-preferred-size: 80px;
+        flex-basis: 80px; }
+  .kt-gutter-widest.kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex-preferred-size: 80px;
+        flex-basis: 80px; }
+  .kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 2;
+        flex: 2; }
+  .kt-row-layout-left-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-row-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 2;
+        flex: 2; }
+  .kt-has-2-columns.kt-custom-first-width-10 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 10%;
+        flex: 0 1 10%; }
+  .kt-has-2-columns.kt-custom-first-width-10 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 90%;
+        flex: 0 1 90%; }
+  .kt-has-2-columns.kt-custom-first-width-15 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 15%;
+        flex: 0 1 15%; }
+  .kt-has-2-columns.kt-custom-first-width-15 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 85%;
+        flex: 0 1 85%; }
+  .kt-has-2-columns.kt-custom-first-width-20 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 20%;
+        flex: 0 1 20%; }
+  .kt-has-2-columns.kt-custom-first-width-20 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 80%;
+        flex: 0 1 80%; }
+  .kt-has-2-columns.kt-custom-first-width-25 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 25%;
+        flex: 0 1 25%; }
+  .kt-has-2-columns.kt-custom-first-width-25 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 75%;
+        flex: 0 1 75%; }
+  .kt-has-2-columns.kt-custom-first-width-30 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 30%;
+        flex: 0 1 30%; }
+  .kt-has-2-columns.kt-custom-first-width-30 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 70%;
+        flex: 0 1 70%; }
+  .kt-has-2-columns.kt-custom-first-width-35 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 35%;
+        flex: 0 1 35%; }
+  .kt-has-2-columns.kt-custom-first-width-35 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 65%;
+        flex: 0 1 65%; }
+  .kt-has-2-columns.kt-custom-first-width-40 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 40%;
+        flex: 0 1 40%; }
+  .kt-has-2-columns.kt-custom-first-width-40 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 60%;
+        flex: 0 1 60%; }
+  .kt-has-2-columns.kt-custom-first-width-45 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 45%;
+        flex: 0 1 45%; }
+  .kt-has-2-columns.kt-custom-first-width-45 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 55%;
+        flex: 0 1 55%; }
+  .kt-has-2-columns.kt-custom-first-width-50 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-has-2-columns.kt-custom-first-width-50 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-has-2-columns.kt-custom-first-width-55 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 55%;
+        flex: 0 1 55%; }
+  .kt-has-2-columns.kt-custom-first-width-55 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 45%;
+        flex: 0 1 45%; }
+  .kt-has-2-columns.kt-custom-first-width-60 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 60%;
+        flex: 0 1 60%; }
+  .kt-has-2-columns.kt-custom-first-width-60 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 40%;
+        flex: 0 1 40%; }
+  .kt-has-2-columns.kt-custom-first-width-65 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 65%;
+        flex: 0 1 65%; }
+  .kt-has-2-columns.kt-custom-first-width-65 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 35%;
+        flex: 0 1 35%; }
+  .kt-has-2-columns.kt-custom-first-width-70 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 70%;
+        flex: 0 1 70%; }
+  .kt-has-2-columns.kt-custom-first-width-70 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 30%;
+        flex: 0 1 30%; }
+  .kt-has-2-columns.kt-custom-first-width-75 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 75%;
+        flex: 0 1 75%; }
+  .kt-has-2-columns.kt-custom-first-width-75 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 25%;
+        flex: 0 1 25%; }
+  .kt-has-2-columns.kt-custom-first-width-80 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 80%;
+        flex: 0 1 80%; }
+  .kt-has-2-columns.kt-custom-first-width-80 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 20%;
+        flex: 0 1 20%; }
+  .kt-has-2-columns.kt-custom-first-width-85 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 85%;
+        flex: 0 1 85%; }
+  .kt-has-2-columns.kt-custom-first-width-85 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 15%;
+        flex: 0 1 15%; }
+  .kt-has-2-columns.kt-custom-first-width-90 > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 0 1 90%;
+        flex: 0 1 90%; }
+  .kt-has-2-columns.kt-custom-first-width-90 > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 0 1 10%;
+        flex: 0 1 10%; }
+  .kt-row-layout-left-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-row-layout-left-half > .wp-block-kadence-column.inner-column-1 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-row-layout-right-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-row-layout-right-half > .wp-block-kadence-column.inner-column-3 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-row-layout-center-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-row-layout-center-half > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-row-layout-center-wide > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-row-layout-center-wide > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 3;
+          flex: 3; }
+  .kt-row-layout-center-exwide > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-row-layout-center-exwide > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 6;
+          flex: 6; }
+  .kt-row-layout-left-forty > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-row-layout-left-forty > .wp-block-kadence-column.inner-column-1 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-row-layout-right-forty > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-row-layout-right-forty > .wp-block-kadence-column.inner-column-4 {
+      -ms-flex: 2;
+          flex: 2; } }
+
+@media (min-width: 768px) and (max-width: 1024px) {
+  .kt-row-column-wrap.kt-tab-layout-equal > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1;
+    width: 0; }
+  .kt-row-layout-row:not(.kt-tab-layout-inherit) {
+    -ms-flex-direction: row;
+        flex-direction: row; }
+  .kt-row-column-wrap.kt-tab-layout-row {
+    -ms-flex-direction: column;
+        flex-direction: column; }
+  .kt-row-column-wrap.kt-tab-layout-row.kt-m-colapse-right-to-left {
+    -ms-flex-direction: column-reverse;
+        flex-direction: column-reverse; }
+  .kt-row-column-wrap.kt-tab-layout-row > .wp-block-kadence-column {
+    -ms-flex: none;
+        flex: none;
+    width: 100%;
+    margin-right: 0; }
+  .kt-has-1-columns.kt-tab-layout-row > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-tab-layout-row.kt-v-gutter-default > .wp-block-kadence-column {
+    margin-bottom: 30px; }
+  .kt-tab-layout-row.kt-v-gutter-skinny > .wp-block-kadence-column {
+    margin-bottom: 10px; }
+  .kt-tab-layout-row.kt-v-gutter-narrow > .wp-block-kadence-column {
+    margin-bottom: 20px; }
+  .kt-tab-layout-row.kt-v-gutter-wide > .wp-block-kadence-column {
+    margin-bottom: 40px; }
+  .kt-tab-layout-row.kt-v-gutter-wider > .wp-block-kadence-column {
+    margin-bottom: 60px; }
+  .kt-tab-layout-row.kt-v-gutter-widest > .wp-block-kadence-column {
+    margin-bottom: 80px; }
+  .kt-tab-layout-row:not(.kt-v-gutter-none) > .wp-block-kadence-column:last-child {
+    margin-bottom: 0px; }
+  .kt-tab-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 2;
+        flex: 2; }
+  .kt-tab-layout-left-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-tab-layout-right-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-tab-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 2;
+        flex: 2; }
+  .kt-tab-layout-left-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-tab-layout-left-half > .wp-block-kadence-column.inner-column-1 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-tab-layout-right-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-tab-layout-right-half > .wp-block-kadence-column.inner-column-3 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-tab-layout-center-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-tab-layout-center-half > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-tab-layout-center-wide > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-tab-layout-center-wide > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 3;
+          flex: 3; }
+  .kt-tab-layout-center-exwide > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-tab-layout-center-exwide > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 6;
+          flex: 6; }
+  .kt-tab-layout-first-row {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-tab-layout-first-row > .wp-block-kadence-column {
+      -ms-flex: 1;
+          flex: 1; }
+      .kt-tab-layout-first-row > .wp-block-kadence-column.inner-column-1 {
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%; }
+    .kt-tab-layout-first-row.kt-v-gutter-default > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 30px; }
+    .kt-tab-layout-first-row.kt-v-gutter-skinny > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 10px; }
+    .kt-tab-layout-first-row.kt-v-gutter-narrow > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 20px; }
+    .kt-tab-layout-first-row.kt-v-gutter-wide > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 40px; }
+    .kt-tab-layout-first-row.kt-v-gutter-wider > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 60px; }
+    .kt-tab-layout-first-row.kt-v-gutter-widest > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 80px; }
+  .kt-tab-layout-last-row {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-tab-layout-last-row > .wp-block-kadence-column {
+      -ms-flex: 1;
+          flex: 1; }
+      .kt-tab-layout-last-row > .wp-block-kadence-column.inner-column-3 {
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%; }
+    .kt-tab-layout-last-row.kt-v-gutter-default > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 30px; }
+    .kt-tab-layout-last-row.kt-v-gutter-skinny > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 10px; }
+    .kt-tab-layout-last-row.kt-v-gutter-narrow > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 20px; }
+    .kt-tab-layout-last-row.kt-v-gutter-wide > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 40px; }
+    .kt-tab-layout-last-row.kt-v-gutter-wider > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 60px; }
+    .kt-tab-layout-last-row.kt-v-gutter-widest > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 80px; }
+  .kt-tab-layout-left-forty > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-tab-layout-left-forty > .wp-block-kadence-column.inner-column-1 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-tab-layout-right-forty > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-tab-layout-right-forty > .wp-block-kadence-column.inner-column-4 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-tab-layout-two-grid {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-tab-layout-two-grid.kt-m-colapse-right-to-left {
+      -ms-flex-direction: row-reverse;
+          flex-direction: row-reverse;
+      -ms-flex-wrap: wrap-reverse;
+          flex-wrap: wrap-reverse; }
+    .kt-tab-layout-two-grid.kt-gutter-default > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 15px);
+          flex: 0 0 calc( 50% - 15px); }
+    .kt-tab-layout-two-grid.kt-gutter-skinny > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 5px);
+          flex: 0 0 calc( 50% - 5px); }
+    .kt-tab-layout-two-grid.kt-gutter-narrow > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 10px);
+          flex: 0 0 calc( 50% - 10px); }
+    .kt-tab-layout-two-grid.kt-gutter-wide > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 20px);
+          flex: 0 0 calc( 50% - 20px); }
+    .kt-tab-layout-two-grid.kt-gutter-wider > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 30px);
+          flex: 0 0 calc( 50% - 30px); }
+    .kt-tab-layout-two-grid.kt-gutter-widest > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 40px);
+          flex: 0 0 calc( 50% - 40px); }
+    .kt-tab-layout-two-grid.kt-gutter-none > .wp-block-kadence-column {
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left) > .wp-block-kadence-column.inner-column-2 {
+      margin-right: 0; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left) > .wp-block-kadence-column.inner-column-4 {
+      margin-right: 0; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-5 {
+      margin-right: 0; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-3 {
+      margin-right: 0; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-1 {
+      margin-right: 0; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-default > .wp-block-kadence-column:last-child {
+      margin-right: 30px; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-skinny > .wp-block-kadence-column:last-child {
+      margin-right: 10px; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-narrow > .wp-block-kadence-column:last-child {
+      margin-right: 20px; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wide > .wp-block-kadence-column:last-child {
+      margin-right: 40px; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wider > .wp-block-kadence-column:last-child {
+      margin-right: 60px; }
+    .kt-tab-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-widest > .wp-block-kadence-column:last-child {
+      margin-right: 80px; }
+  .kt-tab-layout-three-grid {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-tab-layout-three-grid.kt-m-colapse-right-to-left {
+      -ms-flex-direction: row-reverse;
+          flex-direction: row-reverse;
+      -ms-flex-wrap: wrap-reverse;
+          flex-wrap: wrap-reverse; }
+    .kt-tab-layout-three-grid.kt-gutter-default > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 20px);
+          flex: 0 0 calc( 33.33% - 20px); }
+    .kt-tab-layout-three-grid.kt-gutter-skinny > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 8px);
+          flex: 0 0 calc( 33.33% - 8px); }
+    .kt-tab-layout-three-grid.kt-gutter-narrow > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 14px);
+          flex: 0 0 calc( 33.33% - 14px); }
+    .kt-tab-layout-three-grid.kt-gutter-wide > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 28px);
+          flex: 0 0 calc( 33.33% - 28px); }
+    .kt-tab-layout-three-grid.kt-gutter-wider > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 40px);
+          flex: 0 0 calc( 33.33% - 40px); }
+    .kt-tab-layout-three-grid.kt-gutter-widest > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 54px);
+          flex: 0 0 calc( 33.33% - 54px); }
+    .kt-tab-layout-three-grid.kt-gutter-none > .wp-block-kadence-column {
+      -ms-flex: 0 0 33.33%;
+          flex: 0 0 33.33%; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left) > .wp-block-kadence-column.inner-column-3 {
+      margin-right: 0; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-4 {
+      margin-right: 0; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-1 {
+      margin-right: 0; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-default > .wp-block-kadence-column:last-child {
+      margin-right: 30px; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-skinny > .wp-block-kadence-column:last-child {
+      margin-right: 10px; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-narrow > .wp-block-kadence-column:last-child {
+      margin-right: 20px; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wide > .wp-block-kadence-column:last-child {
+      margin-right: 40px; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-wider > .wp-block-kadence-column:last-child {
+      margin-right: 60px; }
+    .kt-tab-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left.kt-gutter-widest > .wp-block-kadence-column:last-child {
+      margin-right: 80px; }
+  .wp-block-kadence-rowlayout [id*="jarallax-container-"] > div {
+    position: fixed !important;
+    width: 100% !important;
+    left: 0 !important;
+    margin-top: 0 !important;
+    height: 100vh !important;
+    -webkit-transform: none !important;
+        -ms-transform: none !important;
+            transform: none !important; }
+  .wp-block-kadence-rowlayout [id*="jarallax-container-"] {
+    -webkit-backface-visibility: hidden;
+            backface-visibility: hidden;
+    clip: rect(auto, auto, auto, auto); } }
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) {
+    @media (min-width: 768px) and (max-width: 1024px) {
+      .wp-block-kadence-rowlayout [id*="jarallax-container-"] {
+        clip: auto !important; } } } }
+
+@media (max-width: 767px) {
+  .kt-row-column-wrap.kt-mobile-layout-equal > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1;
+    width: 0; }
+  .kt-row-column-wrap.kt-mobile-layout-row {
+    -ms-flex-direction: column;
+        flex-direction: column; }
+  .kt-row-column-wrap.kt-mobile-layout-row.kt-m-colapse-right-to-left {
+    -ms-flex-direction: column-reverse;
+        flex-direction: column-reverse; }
+  .kt-row-column-wrap.kt-mobile-layout-row > .wp-block-kadence-column {
+    -ms-flex: none;
+        flex: none;
+    width: 100%;
+    margin-right: 0; }
+  .kt-mobile-layout-row.kt-v-gutter-default > .wp-block-kadence-column {
+    margin-bottom: 30px; }
+  .kt-mobile-layout-row.kt-v-gutter-skinny > .wp-block-kadence-column {
+    margin-bottom: 10px; }
+  .kt-mobile-layout-row.kt-v-gutter-narrow > .wp-block-kadence-column {
+    margin-bottom: 20px; }
+  .kt-mobile-layout-row.kt-v-gutter-wide > .wp-block-kadence-column {
+    margin-bottom: 40px; }
+  .kt-mobile-layout-row.kt-v-gutter-wider > .wp-block-kadence-column {
+    margin-bottom: 60px; }
+  .kt-mobile-layout-row.kt-v-gutter-widest > .wp-block-kadence-column {
+    margin-bottom: 80px; }
+  .kt-mobile-layout-row:not(.kt-v-gutter-none) > .wp-block-kadence-column:last-child {
+    margin-bottom: 0px; }
+  .kt-has-1-columns.kt-mobile-layout-row > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-mobile-layout-left-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 2;
+        flex: 2; }
+  .kt-mobile-layout-left-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-mobile-layout-right-golden > .wp-block-kadence-column.inner-column-1 {
+    -ms-flex: 1;
+        flex: 1; }
+  .kt-mobile-layout-right-golden > .wp-block-kadence-column.inner-column-2 {
+    -ms-flex: 2;
+        flex: 2; }
+  .kt-mobile-layout-left-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-mobile-layout-left-half > .wp-block-kadence-column.inner-column-1 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-mobile-layout-right-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-mobile-layout-right-half > .wp-block-kadence-column.inner-column-3 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-mobile-layout-center-half > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-mobile-layout-center-half > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-mobile-layout-center-wide > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-mobile-layout-center-wide > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 3;
+          flex: 3; }
+  .kt-mobile-layout-center-exwide > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-mobile-layout-center-exwide > .wp-block-kadence-column.inner-column-2 {
+      -ms-flex: 6;
+          flex: 6; }
+  .kt-mobile-layout-first-row {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-mobile-layout-first-row > .wp-block-kadence-column {
+      -ms-flex: 1;
+          flex: 1; }
+      .kt-mobile-layout-first-row > .wp-block-kadence-column.inner-column-1 {
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%; }
+    .kt-mobile-layout-first-row.kt-v-gutter-default > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 30px; }
+    .kt-mobile-layout-first-row.kt-v-gutter-skinny > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 10px; }
+    .kt-mobile-layout-first-row.kt-v-gutter-narrow > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 20px; }
+    .kt-mobile-layout-first-row.kt-v-gutter-wide > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 40px; }
+    .kt-mobile-layout-first-row.kt-v-gutter-wider > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 60px; }
+    .kt-mobile-layout-first-row.kt-v-gutter-widest > .wp-block-kadence-column.inner-column-1 {
+      margin-bottom: 80px; }
+  .kt-mobile-layout-last-row {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-mobile-layout-last-row > .wp-block-kadence-column {
+      -ms-flex: 1;
+          flex: 1; }
+      .kt-mobile-layout-last-row > .wp-block-kadence-column.inner-column-3 {
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%; }
+    .kt-mobile-layout-last-row.kt-v-gutter-default > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 30px; }
+    .kt-mobile-layout-last-row.kt-v-gutter-skinny > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 10px; }
+    .kt-mobile-layout-last-row.kt-v-gutter-narrow > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 20px; }
+    .kt-mobile-layout-last-row.kt-v-gutter-wide > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 40px; }
+    .kt-mobile-layout-last-row.kt-v-gutter-wider > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 60px; }
+    .kt-mobile-layout-last-row.kt-v-gutter-widest > .wp-block-kadence-column.inner-column-3 {
+      margin-top: 80px; }
+  .kt-mobile-layout-left-forty > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-mobile-layout-left-forty > .wp-block-kadence-column.inner-column-1 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-mobile-layout-right-forty > .wp-block-kadence-column {
+    -ms-flex: 1;
+        flex: 1; }
+    .kt-mobile-layout-right-forty > .wp-block-kadence-column.inner-column-4 {
+      -ms-flex: 2;
+          flex: 2; }
+  .kt-mobile-layout-two-grid {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-mobile-layout-two-grid.kt-m-colapse-right-to-left {
+      -ms-flex-direction: row-reverse;
+          flex-direction: row-reverse;
+      -ms-flex-wrap: wrap-reverse;
+          flex-wrap: wrap-reverse; }
+    .kt-mobile-layout-two-grid.kt-gutter-default > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 15px);
+          flex: 0 0 calc( 50% - 15px); }
+    .kt-mobile-layout-two-grid.kt-gutter-skinny > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 5px);
+          flex: 0 0 calc( 50% - 5px); }
+    .kt-mobile-layout-two-grid.kt-gutter-narrow > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 10px);
+          flex: 0 0 calc( 50% - 10px); }
+    .kt-mobile-layout-two-grid.kt-gutter-wide > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 20px);
+          flex: 0 0 calc( 50% - 20px); }
+    .kt-mobile-layout-two-grid.kt-gutter-wider > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 30px);
+          flex: 0 0 calc( 50% - 30px); }
+    .kt-mobile-layout-two-grid.kt-gutter-widest > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 50% - 40px);
+          flex: 0 0 calc( 50% - 40px); }
+    .kt-mobile-layout-two-grid.kt-gutter-none > .wp-block-kadence-column {
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%; }
+    .kt-mobile-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left) > .wp-block-kadence-column.inner-column-2 {
+      margin-right: 0; }
+    .kt-mobile-layout-two-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left) > .wp-block-kadence-column.inner-column-4 {
+      margin-right: 0; }
+    .kt-mobile-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-5 {
+      margin-right: 0; }
+    .kt-mobile-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-3 {
+      margin-right: 0; }
+    .kt-mobile-layout-two-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-1 {
+      margin-right: 0; }
+  .kt-mobile-layout-three-grid {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-mobile-layout-three-grid.kt-m-colapse-right-to-left {
+      -ms-flex-direction: row-reverse;
+          flex-direction: row-reverse;
+      -ms-flex-wrap: wrap-reverse;
+          flex-wrap: wrap-reverse; }
+    .kt-mobile-layout-three-grid.kt-gutter-default > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 20px);
+          flex: 0 0 calc( 33.33% - 20px); }
+    .kt-mobile-layout-three-grid.kt-gutter-skinny > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 8px);
+          flex: 0 0 calc( 33.33% - 8px); }
+    .kt-mobile-layout-three-grid.kt-gutter-narrow > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 14px);
+          flex: 0 0 calc( 33.33% - 14px); }
+    .kt-mobile-layout-three-grid.kt-gutter-wide > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 28px);
+          flex: 0 0 calc( 33.33% - 28px); }
+    .kt-mobile-layout-three-grid.kt-gutter-wider > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 40px);
+          flex: 0 0 calc( 33.33% - 40px); }
+    .kt-mobile-layout-three-grid.kt-gutter-widest > .wp-block-kadence-column {
+      -ms-flex: 0 0 calc( 33.33% - 54px);
+          flex: 0 0 calc( 33.33% - 54px); }
+    .kt-mobile-layout-three-grid.kt-gutter-none > .wp-block-kadence-column {
+      -ms-flex: 0 0 33.33%;
+          flex: 0 0 33.33%; }
+    .kt-mobile-layout-three-grid.kt-row-column-wrap:not(.kt-gutter-none):not(.kt-m-colapse-right-to-left) > .wp-block-kadence-column.inner-column-3 {
+      margin-right: 0; }
+    .kt-mobile-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-4 {
+      margin-right: 0; }
+    .kt-mobile-layout-three-grid.kt-row-column-wrap.kt-m-colapse-right-to-left:not(.kt-gutter-none) > .wp-block-kadence-column.inner-column-1 {
+      margin-right: 0; }
+  .kt-gutter-default:not(.kt-mobile-layout-row) > .wp-block-kadence-column {
+    margin-right: 30px; }
+  .kt-gutter-skinny:not(.kt-mobile-layout-row) > .wp-block-kadence-column {
+    margin-right: 10px; }
+  .kt-gutter-narrow:not(.kt-mobile-layout-row) > .wp-block-kadence-column {
+    margin-right: 20px; }
+  .kt-gutter-wide:not(.kt-mobile-layout-row) > .wp-block-kadence-column {
+    margin-right: 40px; }
+  .kt-gutter-wider:not(.kt-mobile-layout-row) > .wp-block-kadence-column {
+    margin-right: 60px; }
+  .kt-gutter-widest:not(.kt-mobile-layout-row) > .wp-block-kadence-column {
+    margin-right: 80px; }
+  .kt-row-column-wrap:not(.kt-gutter-none):not(.kt-mobile-layout-row):not(.kt-m-colapse-right-to-left) > .wp-block-kadence-column:last-child {
+    margin-right: 0px; }
+  .wp-block-kadence-rowlayout [id*="jarallax-container-"] > div {
+    position: fixed !important;
+    width: 100% !important;
+    left: 0 !important;
+    margin-top: 0 !important;
+    height: 100vh !important;
+    -webkit-transform: none !important;
+        -ms-transform: none !important;
+            transform: none !important; }
+  .wp-block-kadence-rowlayout [id*="jarallax-container-"] {
+    -webkit-backface-visibility: hidden;
+            backface-visibility: hidden;
+    clip: rect(auto, auto, auto, auto); } }
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) {
+    @media (max-width: 767px) {
+      .wp-block-kadence-rowlayout [id*="jarallax-container-"] {
+        clip: auto !important; } } } }
+
+.kt-row-layout-bottom-sep {
+  position: absolute;
+  height: 100px;
+  bottom: -1px;
+  left: 0;
+  overflow: hidden;
+  right: 0;
+  z-index: 1; }
+  .kt-row-layout-bottom-sep svg {
+    position: absolute;
+    bottom: 0px;
+    left: 50%;
+    -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+            transform: translateX(-50%);
+    width: 100.2%;
+    height: 100%;
+    display: block; }
+
+.kt-row-layout-top-sep {
+  position: absolute;
+  height: 100px;
+  top: -1px;
+  left: 0;
+  overflow: hidden;
+  right: 0;
+  z-index: 1; }
+  .kt-row-layout-top-sep svg {
+    position: absolute;
+    top: 0px;
+    left: 50%;
+    -webkit-transform: translateX(-50%) rotate(180deg);
+        -ms-transform: translateX(-50%) rotate(180deg);
+            transform: translateX(-50%) rotate(180deg);
+    width: 100.2%;
+    height: 100%;
+    display: block; }
+
+.kt-row-layout-inner > .kb-blocks-bg-slider {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  padding: 0;
+  margin: 0; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .kb-blocks-bg-slider-init {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    padding: 0;
+    margin: 0; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .slick-dotted.slick-slider {
+    margin: 0; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .slick-track, .kt-row-layout-inner > .kb-blocks-bg-slider .slick-list, .kt-row-layout-inner > .kb-blocks-bg-slider .slick-slide, .kt-row-layout-inner > .kb-blocks-bg-slider .kb-bg-slide-contain {
+    height: 100%; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .slick-list {
+    height: 100% !important; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .kb-bg-slide-contain div.kb-bg-slide {
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .kb-blocks-bg-slider-init:not(.slick-initialized) .kb-bg-slide-contain {
+    display: none; }
+    .kt-row-layout-inner > .kb-blocks-bg-slider .kb-blocks-bg-slider-init:not(.slick-initialized) .kb-bg-slide-contain:first-child {
+      display: block; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .kb-bg-slide-contain div {
+    position: relative;
+    height: 100%; }
+  .kt-row-layout-inner > .kb-blocks-bg-slider .slick-dots {
+    bottom: 0; }
+    .kt-row-layout-inner > .kb-blocks-bg-slider .slick-dots li {
+      z-index: 11; }
+
+.kb-blocks-bg-video-container {
+  bottom: 0;
+  right: 0;
+  top: 0;
+  left: 0;
+  position: absolute;
+  overflow: hidden; }
+
+.kb-blocks-bg-video {
+  -o-object-position: 50% 50%;
+     object-position: 50% 50%;
+  -o-object-fit: cover;
+     object-fit: cover;
+  background-position: center center;
+  width: 100%;
+  height: 100%; }
+
+.kb-background-video-buttons-wrapper {
+  position: absolute;
+  z-index: 11;
+  bottom: 20px;
+  right: 20px; }
+
+.kb-background-video-buttons-wrapper button.kb-toggle-video-btn {
+  padding: 8px;
+  margin: 0 0 0 8px;
+  border: 0;
+  background: rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  font-size: 24px;
+  color: #fff;
+  display: inline-block;
+  opacity: .5;
+  height: 32px;
+  line-height: 16px;
+  -webkit-transition: opacity .3s ease-in-out;
+  -o-transition: opacity .3s ease-in-out;
+  transition: opacity .3s ease-in-out;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+  .kb-background-video-buttons-wrapper button.kb-toggle-video-btn svg {
+    width: 16px;
+    height: 16px;
+    vertical-align: bottom; }
+
+.kb-background-video-buttons-wrapper button.kb-toggle-video-btn:hover {
+  opacity: 1; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.kt-svg-style-stacked .kt-svg-icon {
+  border: 0px solid #444444; }
+
+.kt-svg-icon-wrap {
+  display: inline-block; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend
+ */
+.wp-block-kadence-advancedheading mark {
+  color: #f76a0c;
+  background: transparent;
+  border-style: solid;
+  border-width: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-kadence-tabs .kt-tabs-title-list {
+  margin: 0;
+  padding: 0;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  list-style: none; }
+  .wp-block-kadence-tabs .kt-tabs-title-list li {
+    margin: 0 4px -1px 0;
+    cursor: pointer;
+    list-style: none; }
+    .wp-block-kadence-tabs .kt-tabs-title-list li .kt-tab-title {
+      padding: 8px 16px;
+      display: -ms-flexbox;
+      display: flex;
+      color: #444;
+      -ms-flex-align: center;
+          align-items: center;
+      border-style: solid;
+      border-color: transparent;
+      border-width: 1px 1px 0 1px;
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px;
+      text-decoration: none;
+      -webkit-transition: all .2s ease-in-out;
+      -o-transition: all .2s ease-in-out;
+      transition: all .2s ease-in-out; }
+      .wp-block-kadence-tabs .kt-tabs-title-list li .kt-tab-title:focus {
+        outline: 0;
+        text-decoration: none; }
+      .wp-block-kadence-tabs .kt-tabs-title-list li .kt-tab-title:hover {
+        text-decoration: none; }
+    .wp-block-kadence-tabs .kt-tabs-title-list li.kt-tab-title-active {
+      z-index: 4;
+      text-decoration: none;
+      position: relative; }
+      .wp-block-kadence-tabs .kt-tabs-title-list li.kt-tab-title-active .kt-tab-title {
+        background-color: #fff;
+        border-color: #dee2e6; }
+
+.kt-tabs-icon-side-top .kt-tab-title {
+  -ms-flex-direction: column;
+      flex-direction: column; }
+
+.kt-tabs-accordion-title.kt-tabs-icon-side-top .kt-tab-title {
+  -ms-flex-align: start;
+      align-items: flex-start; }
+
+.kt-tabs-accordion-title .kt-tab-title {
+  padding: 8px 16px;
+  display: -ms-flexbox;
+  display: flex;
+  color: #444;
+  -ms-flex-align: center;
+      align-items: center;
+  border-style: solid;
+  border-color: transparent;
+  border-width: 1px 1px 0 1px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  -webkit-transition: all .2s ease-in-out;
+  -o-transition: all .2s ease-in-out;
+  transition: all .2s ease-in-out; }
+
+.kt-tabs-accordion-title.kt-tab-title-active {
+  z-index: 4; }
+  .kt-tabs-accordion-title.kt-tab-title-active .kt-tab-title {
+    background-color: #fff;
+    border-color: #dee2e6; }
+
+.wp-block-kadence-tabs .kt-tab-inner-content-inner p:last-child {
+  margin-bottom: 0; }
+
+.kt-tab-alignment-center > .kt-tabs-title-list, .kt-tab-alignment-center > .kt-tabs-content-wrap > .kt-tabs-accordion-title a {
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-tab-alignment-right > .kt-tabs-title-list, .kt-tab-alignment-right > .kt-tabs-content-wrap > .kt-tabs-accordion-title a {
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+.kt-tabs-content-wrap:before, .kt-tabs-content-wrap:after {
+  content: '';
+  clear: both;
+  display: table; }
+
+.kt-tabs-content-wrap {
+  position: relative; }
+
+.kt-tabs-wrap {
+  margin: 0 auto; }
+
+.kt-tabs-wrap .wp-block-kadence-tab {
+  border: 1px solid #dee2e6;
+  padding: 20px;
+  text-align: left; }
+
+.kt-tabs-wrap .wp-block-kadence-tab[role="tabpanel"] {
+  display: none; }
+
+.kt-tabs-wrap.kt-active-tab-1 > .kt-tabs-content-wrap > .kt-inner-tab-1 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-2 > .kt-tabs-content-wrap > .kt-inner-tab-2 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-3 > .kt-tabs-content-wrap > .kt-inner-tab-3 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-4 > .kt-tabs-content-wrap > .kt-inner-tab-4 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-5 > .kt-tabs-content-wrap > .kt-inner-tab-5 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-6 > .kt-tabs-content-wrap > .kt-inner-tab-6 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-7 > .kt-tabs-content-wrap > .kt-inner-tab-7 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-8 > .kt-tabs-content-wrap > .kt-inner-tab-8 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-9 > .kt-tabs-content-wrap > .kt-inner-tab-9 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-10 > .kt-tabs-content-wrap > .kt-inner-tab-10 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-11 > .kt-tabs-content-wrap > .kt-inner-tab-11 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-12 > .kt-tabs-content-wrap > .kt-inner-tab-12 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-13 > .kt-tabs-content-wrap > .kt-inner-tab-13 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-14 > .kt-tabs-content-wrap > .kt-inner-tab-14 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-15 > .kt-tabs-content-wrap > .kt-inner-tab-15 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-16 > .kt-tabs-content-wrap > .kt-inner-tab-16 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-17 > .kt-tabs-content-wrap > .kt-inner-tab-17 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-18 > .kt-tabs-content-wrap > .kt-inner-tab-18 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-19 > .kt-tabs-content-wrap > .kt-inner-tab-19 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-20 > .kt-tabs-content-wrap > .kt-inner-tab-20 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-21 > .kt-tabs-content-wrap > .kt-inner-tab-21 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-22 > .kt-tabs-content-wrap > .kt-inner-tab-22 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-23 > .kt-tabs-content-wrap > .kt-inner-tab-23 {
+  display: block; }
+
+.kt-tabs-wrap.kt-active-tab-24 > .kt-tabs-content-wrap > .kt-inner-tab-24 {
+  display: block; }
+
+.kb-tab-titles-wrap {
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -ms-flex-direction: column;
+      flex-direction: column; }
+
+.kt-title-sub-text {
+  font-size: 14px;
+  line-height: 24px; }
+
+.kt-tabs-layout-vtabs:after, .kt-tabs-wrap:after {
+  clear: both;
+  display: table;
+  content: ''; }
+
+.kt-tabs-layout-vtabs > .kt-tabs-title-list {
+  float: left;
+  width: 30%;
+  -ms-flex-direction: column;
+      flex-direction: column; }
+  .kt-tabs-layout-vtabs > .kt-tabs-title-list li {
+    margin: 0 -1px 4px 0; }
+    .kt-tabs-layout-vtabs > .kt-tabs-title-list li .kt-tab-title {
+      border-width: 1px 0px 1px 1px;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0; }
+    .kt-tabs-layout-vtabs > .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title {
+      -ms-flex-align: start;
+          align-items: flex-start; }
+
+.kt-tabs-layout-vtabs > .kt-tabs-content-wrap {
+  float: left;
+  width: 70%; }
+
+.kt-tabs-layout-vtabs.kt-tab-alignment-left > .kt-tabs-title-list li .kt-tab-title {
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+
+.kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-title-list {
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+  .kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-title-list li {
+    text-align: center; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-title-list li .kt-tab-title {
+      -ms-flex-pack: center;
+          justify-content: center;
+      -ms-flex-align: center;
+          align-items: center; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-center > .kt-tabs-title-list li .kb-tab-titles-wrap {
+      -ms-flex-align: center;
+          align-items: center; }
+
+.kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-title-list {
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+  .kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-title-list li {
+    text-align: right; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-title-list li .kt-tab-title {
+      -ms-flex-pack: end;
+          justify-content: flex-end;
+      -ms-flex-align: center;
+          align-items: center; }
+    .kt-tabs-layout-vtabs.kt-tab-alignment-right > .kt-tabs-title-list li .kb-tab-titles-wrap {
+      -ms-flex-align: end;
+          align-items: flex-end; }
+
+.kt-tabs-svg-show-only .kt-button-text, .kt-tabs-svg-show-only .kb-tab-titles-wrap {
+  display: none; }
+
+.kt-tabs-accordion-title a {
+  padding: 8px 16px;
+  display: -ms-flexbox;
+  display: flex;
+  color: #444;
+  -ms-flex-align: center;
+      align-items: center;
+  border-style: solid;
+  border-color: transparent;
+  border-width: 1px 1px 0 1px; }
+  .kt-tabs-accordion-title a.kt-tab-title-active {
+    background-color: #fff;
+    border-color: #dee2e6; }
+
+.wp-block-kadence-tabs .kt-tabs-content-wrap .kt-tabs-accordion-title .kt-tab-title {
+  border-radius: 0; }
+
+.kt-tabs-svg-show-only .kt-title-text {
+  display: none; }
+
+.kt-title-svg-side-left {
+  padding-right: 5px; }
+
+.kt-title-svg-side-right {
+  padding-left: 5px; }
+
+.kt-tabs-svg-show-only .kt-title-svg-side-right {
+  padding-left: 0px; }
+
+.kt-tabs-svg-show-only .kt-title-svg-side-left {
+  padding-right: 0px; }
+
+.kt-tabs-accordion-title {
+  display: none; }
+
+@media (min-width: 767px) and (max-width: 1024px) {
+  .kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list {
+    float: none;
+    width: 100%;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li {
+      margin: 0 4px -1px 0; }
+      .kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li .kt-tab-title {
+        border-width: 1px 1px 0px 1px;
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px; }
+      .kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title {
+        -ms-flex-align: center;
+            align-items: center; }
+  .kt-tabs-tablet-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-content-wrap {
+    float: none;
+    width: 100%; }
+  .kt-tabs-tablet-layout-accordion > .kt-tabs-title-list {
+    display: none; }
+  .kt-tabs-tablet-layout-accordion > .kt-tabs-content-wrap > .kt-tabs-accordion-title {
+    display: block; }
+  .kt-tabs-tablet-layout-accordion > .kt-tabs-content-wrap {
+    float: none;
+    width: 100%; }
+  .kt-tabs-tablet-layout-vtabs .kt-tabs-title-list {
+    float: left;
+    width: 30%;
+    -ms-flex-direction: column;
+        flex-direction: column; }
+    .kt-tabs-tablet-layout-vtabs .kt-tabs-title-list li {
+      margin: 0 -1px 4px 0; }
+      .kt-tabs-tablet-layout-vtabs .kt-tabs-title-list li .kt-tab-title {
+        border-width: 1px 0px 1px 1px;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0; }
+      .kt-tabs-tablet-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title {
+        -ms-flex-align: start;
+            align-items: flex-start; }
+  .kt-tabs-tablet-layout-vtabs .kt-tabs-content-wrap {
+    float: left;
+    width: 70%; }
+  .kt-tabs-tablet-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list {
+    -ms-flex-pack: start;
+        justify-content: flex-start; }
+    .kt-tabs-tablet-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li {
+      text-align: center; }
+      .kt-tabs-tablet-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li .kt-tab-title {
+        -ms-flex-pack: center;
+            justify-content: center; }
+  .kt-tabs-tablet-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list {
+    -ms-flex-pack: start;
+        justify-content: flex-start; }
+    .kt-tabs-tablet-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li {
+      text-align: right; }
+      .kt-tabs-tablet-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li .kt-tab-title {
+        -ms-flex-pack: end;
+            justify-content: flex-end; } }
+
+@media (max-width: 767px) {
+  .kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list {
+    float: none;
+    width: 100%;
+    -ms-flex-direction: row;
+        flex-direction: row; }
+    .kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li {
+      margin: 0 4px -1px 0; }
+      .kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li .kt-tab-title {
+        border-width: 1px 1px 0px 1px;
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px; }
+      .kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title {
+        -ms-flex-align: center;
+            align-items: center; }
+  .kt-tabs-mobile-layout-tabs.kt-tabs-layout-vtabs .kt-tabs-content-wrap {
+    float: none;
+    width: 100%; }
+  .kt-tabs-mobile-layout-accordion > .kt-tabs-title-list {
+    display: none; }
+  .kt-tabs-mobile-layout-accordion > .kt-tabs-content-wrap > .kt-tabs-accordion-title {
+    display: block; }
+  .kt-tabs-mobile-layout-accordion > .kt-tabs-content-wrap {
+    float: none;
+    width: 100%; }
+  .kt-tabs-mobile-layout-vtabs .kt-tabs-title-list {
+    float: left;
+    width: 30%;
+    -ms-flex-direction: column;
+        flex-direction: column; }
+    .kt-tabs-mobile-layout-vtabs .kt-tabs-title-list li {
+      margin: 0 -1px 4px 0; }
+      .kt-tabs-mobile-layout-vtabs .kt-tabs-title-list li .kt-tab-title {
+        border-width: 1px 0px 1px 1px;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0; }
+      .kt-tabs-mobile-layout-vtabs .kt-tabs-title-list li.kt-tabs-icon-side-top .kt-tab-title {
+        -ms-flex-align: start;
+            align-items: flex-start; }
+  .kt-tabs-mobile-layout-vtabs .kt-tabs-content-wrap {
+    float: left;
+    width: 70%; }
+  .kt-tabs-mobile-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list {
+    -ms-flex-pack: start;
+        justify-content: flex-start; }
+    .kt-tabs-mobile-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li {
+      text-align: center; }
+      .kt-tabs-mobile-layout-vtabs.kt-tab-alignment-center .kt-tabs-title-list li .kt-tab-title {
+        -ms-flex-pack: center;
+            justify-content: center; }
+  .kt-tabs-mobile-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list {
+    -ms-flex-pack: start;
+        justify-content: flex-start; }
+    .kt-tabs-mobile-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li {
+      text-align: right; }
+      .kt-tabs-mobile-layout-vtabs.kt-tab-alignment-right .kt-tabs-title-list li .kt-tab-title {
+        -ms-flex-pack: end;
+            justify-content: flex-end; } }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-8 > li {
+  -ms-flex: 0 1 12.5%;
+      flex: 0 1 12.5%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-7 > li {
+  -ms-flex: 0 1 14.28%;
+      flex: 0 1 14.28%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-6 > li {
+  -ms-flex: 0 1 16.67%;
+      flex: 0 1 16.67%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-5 > li {
+  -ms-flex: 0 1 20%;
+      flex: 0 1 20%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-4 > li {
+  -ms-flex: 0 1 25%;
+      flex: 0 1 25%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-3 > li {
+  -ms-flex: 0 1 33.33%;
+      flex: 0 1 33.33%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-2 > li {
+  -ms-flex: 0 1 50%;
+      flex: 0 1 50%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-1 > li {
+  -ms-flex: 0 1 100%;
+      flex: 0 1 100%; }
+
+ul.kt-tabs-title-list.kb-tab-title-columns-1 > li > .kt-tab-title {
+  margin-right: 0px !important; }
+
+ul.kt-tabs-title-list.kb-tabs-list-columns > li:last-child > .kt-tab-title {
+  margin-right: 0px !important; }
+
+ul.kt-tabs-title-list.kb-tabs-list-columns .kt-tab-title {
+  -ms-flex-pack: center;
+      justify-content: center;
+  text-align: center; }
+
+ul.kt-tabs-title-list.kb-tabs-list-columns {
+  word-break: break-word; }
+
+.kt-tab-alignment-center ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap {
+  -ms-flex-align: center;
+      align-items: center; }
+
+.kt-tab-alignment-right ul.kt-tabs-title-list.kb-tabs-list-columns .kb-tab-titles-wrap {
+  -ms-flex-align: end;
+      align-items: flex-end; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.kadence-info-box-image-intrisic {
+  height: 0; }
+
+.kt-info-halign-center {
+  text-align: center; }
+  .kt-info-halign-center .kadence-info-box-image-inner-intrisic-container {
+    margin: 0 auto; }
+
+.kt-info-halign-right {
+  text-align: right; }
+  .kt-info-halign-right .kadence-info-box-image-inner-intrisic-container {
+    margin: 0 0 0 auto; }
+
+.kt-info-halign-left {
+  text-align: left; }
+  .kt-info-halign-left .kadence-info-box-image-inner-intrisic-container {
+    margin: 0 auto 0 0; }
+
+.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media {
+  display: inline-block;
+  max-width: 100%; }
+
+.kt-blocks-info-box-media-align-top .kt-infobox-textcontent {
+  display: block; }
+
+.kt-blocks-info-box-text {
+  color: #555555; }
+
+.wp-block-kadence-infobox .kt-blocks-info-box-text {
+  margin-bottom: 0; }
+
+.kt-blocks-info-box-link-wrap:hover {
+  background: #f2f2f2;
+  border-color: #eeeeee; }
+
+.kt-blocks-info-box-media, .kt-blocks-info-box-link-wrap {
+  border: 0 solid transparent;
+  -webkit-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  -o-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95); }
+
+.kt-blocks-info-box-title, .kt-blocks-info-box-text, .kt-blocks-info-box-learnmore, .kt-info-svg-image {
+  -webkit-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  -o-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  transition: all 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95); }
+
+.kt-blocks-info-box-media {
+  border-color: #444444;
+  color: #444444;
+  padding: 10px;
+  margin: 0 15px 0 15px; }
+  .kt-blocks-info-box-media img {
+    padding: 0;
+    margin: 0; }
+
+.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media {
+  margin: 0; }
+
+.kt-blocks-info-box-media-align-top .kt-blocks-info-box-media-container {
+  margin: 0 15px 0 15px; }
+
+.kt-blocks-info-box-link-wrap:hover .kt-blocks-info-box-media {
+  border-color: #444444; }
+
+.kt-blocks-info-box-link-wrap {
+  display: block;
+  background: #f2f2f2;
+  padding: 20px;
+  border-color: #eeeeee; }
+
+.kt-blocks-info-box-learnmore {
+  border: 0 solid transparent;
+  display: block; }
+
+.wp-block-kadence-infobox .kt-blocks-info-box-learnmore-wrap {
+  display: inline-block;
+  width: auto; }
+
+.kt-blocks-info-box-media-align-left {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+
+.kt-blocks-info-box-media-align-right {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: start;
+      justify-content: flex-start;
+  -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse; }
+
+.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-top, .kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-top {
+  -ms-flex-align: start;
+      align-items: flex-start; }
+
+.kt-blocks-info-box-media-align-right.kb-info-box-vertical-media-align-bottom, .kt-blocks-info-box-media-align-left.kb-info-box-vertical-media-align-bottom {
+  -ms-flex-align: end;
+      align-items: flex-end; }
+
+.kt-blocks-info-box-media .kt-info-box-image, .kt-blocks-info-box-media-container {
+  max-width: 100%; }
+
+.kadence-info-box-image-intrisic.kb-info-box-image-type-svg {
+  height: auto;
+  padding-bottom: 0; }
+
+.kt-info-animate-grayscale img, .kt-info-animate-grayscale-border-draw img {
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  -webkit-transition: 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  -o-transition: 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95);
+  transition: 0.3s cubic-bezier(0.17, 0.67, 0.35, 0.95); }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale img, .kt-blocks-info-box-link-wrap:hover .kt-info-animate-grayscale-border-draw img {
+  -webkit-filter: grayscale(0);
+  filter: grayscale(0); }
+
+.kt-info-animate-flip, .kt-info-icon-animate-flip {
+  -webkit-perspective: 1000;
+          perspective: 1000; }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-animate-flip .kadence-info-box-image-inner-intrisic, .kt-blocks-info-box-link-wrap:hover .kt-info-icon-animate-flip .kadence-info-box-icon-inner-container {
+  -webkit-transform: rotateY(180deg);
+          transform: rotateY(180deg); }
+
+.kt-info-animate-flip .kadence-info-box-image-inner-intrisic, .kt-info-icon-animate-flip .kadence-info-box-icon-inner-container {
+  -webkit-transition: 0.6s;
+  -o-transition: 0.6s;
+  transition: 0.6s;
+  -webkit-transform-style: preserve-3d;
+          transform-style: preserve-3d;
+  position: relative; }
+
+.kt-info-animate-flip .kt-info-box-image-flip, .kt-info-icon-animate-flip .kt-info-svg-icon-flip {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
+  position: absolute;
+  top: 0;
+  left: 0; }
+
+.kt-info-animate-flip .kt-info-box-image, .kt-info-icon-animate-flip .kt-info-svg-icon {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.kt-info-animate-flip .kt-info-box-image, .kt-info-icon-animate-flip .kt-info-svg-icon {
+  z-index: 2; }
+
+.kt-info-animate-flip .kt-info-box-image-flip, .kt-info-icon-animate-flip .kt-info-svg-icon-flip {
+  -webkit-transform: rotateY(180deg);
+          transform: rotateY(180deg); }
+
+.kt-info-media-animate-drawborder, .kt-info-media-animate-grayscale-border-draw {
+  position: relative;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+  .kt-info-media-animate-drawborder::before, .kt-info-media-animate-drawborder::after, .kt-info-media-animate-grayscale-border-draw::before, .kt-info-media-animate-grayscale-border-draw::after {
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    content: '';
+    position: absolute;
+    border: 0px solid transparent;
+    width: 0;
+    height: 0; }
+  .kt-info-media-animate-drawborder::before, .kt-info-media-animate-drawborder::after, .kt-info-media-animate-grayscale-border-draw::before, .kt-info-media-animate-grayscale-border-draw::after {
+    top: 0;
+    left: 0; }
+  .kt-info-media-animate-drawborder:after, .kt-info-media-animate-grayscale-border-draw:after {
+    -webkit-transform: rotate(-90deg);
+        -ms-transform: rotate(-90deg);
+            transform: rotate(-90deg); }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:before, .kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:before {
+  width: 100%;
+  height: 100%;
+  -webkit-transition: border-top-color 0.15s linear, border-right-color 0.15s linear 0.1s, border-bottom-color 0.15s linear 0.2s;
+  -o-transition: border-top-color 0.15s linear, border-right-color 0.15s linear 0.1s, border-bottom-color 0.15s linear 0.2s;
+  transition: border-top-color 0.15s linear, border-right-color 0.15s linear 0.1s, border-bottom-color 0.15s linear 0.2s; }
+
+.kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-drawborder:after, .kt-blocks-info-box-link-wrap:hover .kt-info-media-animate-grayscale-border-draw:after {
+  width: 100%;
+  height: 100%;
+  -webkit-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg);
+  -webkit-transition: border-bottom-width 0s linear 0.35s, -webkit-transform 0.4s linear 0s;
+  transition: border-bottom-width 0s linear 0.35s, -webkit-transform 0.4s linear 0s;
+  -o-transition: transform 0.4s linear 0s, border-bottom-width 0s linear 0.35s;
+  transition: transform 0.4s linear 0s, border-bottom-width 0s linear 0.35s;
+  transition: transform 0.4s linear 0s, border-bottom-width 0s linear 0.35s, -webkit-transform 0.4s linear 0s; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.kt-accordion-wrap .kt-accordion-header-wrap {
+  margin: 0;
+  padding: 0; }
+
+.kt-blocks-accordion-header {
+  -ms-flex-line-pack: justify;
+      align-content: space-between;
+  -ms-flex-align: center;
+      align-items: center;
+  background-color: #f2f2f2;
+  border: 0 solid transparent;
+  border-radius: 0px;
+  color: #555555;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 18px;
+  padding: 10px 14px;
+  position: relative;
+  line-height: 24px;
+  text-align: left;
+  -webkit-transition: all ease-in-out .2s;
+  -o-transition: all ease-in-out .2s;
+  transition: all ease-in-out .2s;
+  width: 100%;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  text-shadow: none; }
+
+.kt-blocks-accordion-header:focus {
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  text-shadow: none; }
+
+.kt-blocks-accordion-header:hover {
+  background-color: #eeeeee;
+  color: #444444;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  text-shadow: none; }
+  .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after, .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before {
+    background-color: #444444; }
+
+.kt-blocks-accordion-header.kt-accordion-panel-active {
+  background-color: #444444;
+  color: #ffffff; }
+  .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before {
+    background-color: #ffffff; }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger {
+  background-color: #444444; }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before {
+  background-color: #eeeeee; }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger {
+  background-color: #ffffff; }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before {
+  background-color: #444444; }
+
+.kt-blocks-accordion-title-wrap {
+  display: -ms-flexbox;
+  display: flex;
+  padding-right: 10px; }
+
+.kt-accodion-icon-side-left .kt-blocks-accordion-title-wrap {
+  padding-right: 0px; }
+
+.kt-pane-header-alignment-center button.kt-blocks-accordion-header {
+  text-align: center; }
+
+.kt-pane-header-alignment-center button.kt-blocks-accordion-header .kt-blocks-accordion-title-wrap {
+  -ms-flex-positive: 2;
+      flex-grow: 2;
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-pane-header-alignment-right button.kt-blocks-accordion-header {
+  text-align: right; }
+
+.kt-pane-header-alignment-right button.kt-blocks-accordion-header .kt-blocks-accordion-title-wrap {
+  -ms-flex-positive: 2;
+      flex-grow: 2;
+  -ms-flex-pack: end;
+      justify-content: flex-end; }
+
+.kt-pane-header-alignment-right button.kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger {
+  margin-left: 10px; }
+
+.kt-acccordion-button-label-hide .kt-blocks-accordion-title {
+  display: none; }
+
+.kt-accordion-panel-inner:after {
+  clear: both;
+  display: table;
+  content: ''; }
+
+.kt-accodion-icon-style-none .kt-blocks-accordion-icon-trigger {
+  display: none; }
+
+.kt-accodion-icon-side-left .kt-blocks-accordion-icon-trigger {
+  -ms-flex-order: -1;
+      order: -1;
+  margin-left: 0;
+  margin-right: 10px; }
+
+.kt-blocks-accordion-icon-trigger {
+  display: block;
+  height: 24px;
+  margin-left: auto;
+  position: relative;
+  -webkit-transition: all ease-in-out 0.2s;
+  -o-transition: all ease-in-out 0.2s;
+  transition: all ease-in-out 0.2s;
+  width: 24px;
+  min-width: 24px;
+  -webkit-box-sizing: content-box;
+          box-sizing: content-box; }
+
+.kt-blocks-accordion-icon-trigger:after, .kt-blocks-accordion-icon-trigger:before {
+  background-color: #333; }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg); }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before {
+  content: "";
+  height: 4px;
+  position: absolute;
+  -webkit-transition: all ease-in-out 0.1333333333s;
+  -o-transition: all ease-in-out 0.1333333333s;
+  transition: all ease-in-out 0.1333333333s;
+  width: 20px;
+  left: 2px;
+  top: 10px; }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-basic .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger {
+  background-color: #333;
+  border-radius: 50%; }
+
+.kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-basiccircle .kt-blocks-accordion-icon-trigger:before {
+  background-color: #fff;
+  width: 16px;
+  left: 4px;
+  top: 10px; }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg); }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg); }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before {
+  content: "";
+  height: 4px;
+  position: absolute;
+  -webkit-transition: all ease-in-out 0.1333333333s;
+  -o-transition: all ease-in-out 0.1333333333s;
+  transition: all ease-in-out 0.1333333333s;
+  width: 20px;
+  left: 2px;
+  top: 10px; }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-xclose .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(0deg);
+      -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger {
+  background-color: #333;
+  border-radius: 50%; }
+
+.kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-xclosecircle .kt-blocks-accordion-icon-trigger:before {
+  background-color: #fff;
+  width: 16px;
+  left: 4px;
+  top: 10px; }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg); }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-header.kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg); }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  content: "";
+  height: 2px;
+  position: absolute;
+  top: 11px;
+  -webkit-transition: all ease-in-out 0.1333333333s;
+  -o-transition: all ease-in-out 0.1333333333s;
+  transition: all ease-in-out 0.1333333333s;
+  width: 12px; }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:before, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  left: 2px;
+  -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+          transform: rotate(45deg);
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-arrow .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after {
+  -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+          transform: rotate(-45deg);
+  right: 2px;
+  -webkit-transform-origin: 50%;
+      -ms-transform-origin: 50%;
+          transform-origin: 50%; }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger {
+  background-color: #333;
+  border-radius: 50%; }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after, .kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  background-color: #fff;
+  width: 10px; }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:before {
+  left: 4px; }
+
+.kt-accodion-icon-style-arrowcircle .kt-blocks-accordion-icon-trigger:after {
+  right: 4px; }
+
+.kt-accordion-header-wrap {
+  margin-top: 8px; }
+
+.kt-accordion-inner-wrap .wp-block-kadence-pane:first-child .kt-accordion-header-wrap {
+  margin-top: 0px; }
+
+.kt-accordion-panel-inner {
+  padding: 20px;
+  border: 1px solid #eee;
+  border-top: 0; }
+
+.kt-accordion-panel {
+  overflow: auto;
+  display: block; }
+  .kt-accordion-panel.kt-accordion-panel-hidden {
+    max-height: 0 !important;
+    overflow: hidden;
+    display: none; }
+
+.kt-accordion-initialized .kt-panel-is-collapsing, .kt-accordion-initialized .kt-panel-is-expanding {
+  -webkit-transition: height 0.45s ease;
+  -o-transition: height 0.45s ease;
+  transition: height 0.45s ease;
+  position: relative;
+  height: 0;
+  overflow: hidden; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-kadence-iconlist ul.kt-svg-icon-list {
+  padding: 0;
+  list-style: none;
+  margin: 0 0 10px 0; }
+  .wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-align: center;
+        align-items: center;
+    padding: 0;
+    margin: 0 0 5px 0; }
+    .wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap .kt-svg-icon-list-single {
+      margin-right: 10px;
+      padding: 4px 0;
+      display: inline-block !important; }
+    .wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap .kt-svg-icon-link {
+      display: -ms-flexbox;
+      display: flex;
+      -ms-flex-align: center;
+          align-items: center; }
+  .wp-block-kadence-iconlist ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap:last-child {
+    margin-bottom: 0; }
+
+.wp-block-kadence-iconlist.kt-list-icon-aligntop ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap {
+  -ms-flex-align: start;
+      align-items: flex-start; }
+
+.wp-block-kadence-iconlist.kt-list-icon-alignbottom ul.kt-svg-icon-list .kt-svg-icon-list-item-wrap {
+  -ms-flex-align: end;
+      align-items: flex-end; }
+
+.wp-block-kadence-iconlist.aligncenter .kt-svg-icon-list-item-wrap {
+  -ms-flex-pack: center;
+      justify-content: center; }
+
+.kt-svg-icon-list-style-stacked .kt-svg-icon-list-single {
+  border: 0px solid transparent; }
+
+.kt-svg-icon-list-columns-2 ul.kt-svg-icon-list {
+  grid-template-columns: 50% auto;
+  grid-template-rows: auto;
+  display: grid; }
+
+.kt-svg-icon-list-columns-3 ul.kt-svg-icon-list {
+  grid-template-columns: 33% 33% auto;
+  grid-template-rows: auto;
+  display: grid; }
+
+.kt-info-icon-animate-flip .kadence-info-box-icon-inner-container {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-kadence-testimonials .kt-blocks-carousel {
+  padding-bottom: 35px;
+  margin-left: -15px;
+  margin-right: -15px; }
+
+.wp-block-kadence-testimonials .kt-blocks-carousel.kt-carousel-container-dotstyle-none {
+  padding-bottom: 0; }
+
+.wp-block-kadence-testimonials .kt-blocks-carousel .kt-blocks-carousel-init:not(.kt-carousel-arrowstyle-none) {
+  padding-left: 35px;
+  padding-right: 35px; }
+
+.wp-block-kadence-testimonials .kt-blocks-carousel .kt-blocks-testimonial-carousel-item {
+  padding: 0 15px; }
+
+.kt-testimonial-grid-wrap {
+  display: -ms-grid;
+  display: grid;
+  -ms-grid-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
+  grid-gap: 30px 30px; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap {
+  margin: 0 30px 30px 0;
+  width: auto; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:last-child {
+  margin-right: 0; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(1) {
+  -ms-grid-column: 1; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(2) {
+  -ms-grid-column: 2; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(3) {
+  -ms-grid-column: 3; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(4) {
+  -ms-grid-column: 4; }
+
+.kt-testimonial-grid-wrap .kt-testimonial-item-wrap:nth-child(5) {
+  -ms-grid-column: 5; }
+
+@supports (grid-gap: 30px 30px) {
+  .kt-testimonial-grid-wrap .kt-testimonial-item-wrap {
+    margin: 0 auto;
+    width: 100%; }
+  .kt-testimonial-grid-wrap .kt-testimonial-item-wrap:last-child {
+    margin-right: auto; } }
+
+.kt-testimonial-columns-1 .kt-testimonial-grid-wrap {
+  display: block; }
+
+.kt-testimonial-columns-3 .kt-testimonial-grid-wrap {
+  -ms-grid-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr; }
+
+.kt-testimonial-columns-4 .kt-testimonial-grid-wrap {
+  -ms-grid-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr; }
+
+.kt-testimonial-columns-5 .kt-testimonial-grid-wrap {
+  -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr; }
+
+@media (min-width: 1200px) and (max-width: 1499px) {
+  .kt-t-xl-col-1 .kt-testimonial-grid-wrap {
+    display: block; }
+  .kt-t-xl-col-2 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr; }
+  .kt-t-xl-col-3 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr; }
+  .kt-t-xl-col-4 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr; }
+  .kt-t-xl-col-5 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr; } }
+
+@media (min-width: 992px) and (max-width: 1199px) {
+  .kt-t-lg-col-1 .kt-testimonial-grid-wrap {
+    display: block; }
+  .kt-t-lg-col-2 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr; }
+  .kt-t-lg-col-3 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr; }
+  .kt-t-lg-col-4 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr; }
+  .kt-t-lg-col-5 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr; } }
+
+@media (min-width: 768px) and (max-width: 991px) {
+  .kt-t-md-col-1 .kt-testimonial-grid-wrap {
+    display: block; }
+  .kt-t-md-col-2 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr; }
+  .kt-t-md-col-3 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr; }
+  .kt-t-md-col-4 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr; }
+  .kt-t-md-col-5 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr; } }
+
+@media (min-width: 544px) and (max-width: 767px) {
+  .kt-t-sm-col-1 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr;
+    display: block; }
+  .kt-t-sm-col-2 .kt-testimonial-grid-wrap {
+    grid-template-columns: 1fr 1fr; }
+  .kt-t-sm-col-3 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr; }
+  .kt-t-sm-col-4 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr; }
+  .kt-t-sm-col-5 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr; } }
+
+@media (max-width: 543px) {
+  .kt-t-xs-col-1 .kt-testimonial-grid-wrap {
+    display: block; }
+  .kt-t-xs-col-2 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr; }
+  .kt-t-xs-col-3 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr; }
+  .kt-t-xs-col-4 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr; }
+  .kt-t-xs-col-5 .kt-testimonial-grid-wrap {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr; } }
+
+.kt-testimonial-media-inner-wrap {
+  overflow: hidden;
+  border: 0 solid transparent;
+  width: 60px;
+  margin: 0 15px 0 0;
+  border-radius: 100%; }
+  .kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic {
+    padding-bottom: 100%;
+    height: 0;
+    position: relative; }
+  .kt-testimonial-media-inner-wrap .kt-testimonial-image {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    padding: 0;
+    border-radius: 100%; }
+  .kt-testimonial-media-inner-wrap .kt-svg-testimonial-icon {
+    position: absolute;
+    width: 100%;
+    height: 100%; }
+
+.kt-testimonial-item-wrap {
+  border: 0 solid transparent;
+  max-width: 500px;
+  text-align: center;
+  margin: 0 auto; }
+
+.kt-testimonial-meta-wrap {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: center;
+      justify-content: center;
+  -ms-flex-align: center;
+      align-items: center;
+  margin-top: 10px; }
+  .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+    text-align: left; }
+
+.kt-svg-testimonial-global-icon {
+  border: 2px solid #eeeeee;
+  border-radius: 100%;
+  background: transparent;
+  color: #444444;
+  padding: 20px; }
+
+.kt-svg-testimonial-global-icon-wrap {
+  margin: 0 0 10px 0; }
+
+.kt-testimonial-style-card .kt-testimonial-media-inner-wrap {
+  width: auto;
+  margin: 0 0 15px 0;
+  border-radius: 0; }
+  .kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kadence-testimonial-image-intrisic {
+    padding-bottom: 50%; }
+  .kt-testimonial-style-card .kt-testimonial-media-inner-wrap .kt-testimonial-image {
+    border-radius: 0; }
+
+.kt-testimonial-style-card .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+  text-align: center; }
+
+.kt-testimonial-style-card.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap {
+  margin: 0 0 15px 0; }
+
+.kt-testimonial-style-bubble .kt-testimonial-text-wrap {
+  border: 2px solid #eee;
+  padding: 20px;
+  position: relative;
+  border-radius: 10px; }
+  .kt-testimonial-style-bubble .kt-testimonial-text-wrap:after {
+    height: 0;
+    left: 50%;
+    top: 100%;
+    position: absolute;
+    border-top: 14px solid #eee;
+    border-bottom: 14px solid transparent;
+    border-left: 14px solid transparent;
+    border-right: 14px solid transparent;
+    content: '';
+    -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+            transform: translateX(-50%);
+    width: 0; }
+
+.kt-testimonial-style-bubble .kt-testimonial-meta-wrap {
+  margin-top: 20px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-left .kt-testimonial-meta-wrap {
+  margin-left: 6px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-left.kt-testimonials-media-off .kt-testimonial-meta-wrap {
+  margin-left: 20px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-right .kt-testimonial-meta-wrap {
+  margin-right: 6px; }
+
+.kt-testimonial-style-bubble.kt-testimonial-halign-right.kt-testimonials-media-off .kt-testimonial-meta-wrap {
+  margin-right: 20px; }
+
+.kt-testimonial-style-bubble .kt-svg-testimonial-global-icon {
+  background: #fff; }
+
+.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap {
+  margin: -55px 0 10px 0; }
+
+.kt-testimonial-style-bubble.kt-testimonials-icon-on .kt-testimonial-item-wrap {
+  padding-top: 55px; }
+
+.kt-testimonial-halign-center.kt-testimonial-media-off .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+  text-align: center; }
+
+.kt-testimonial-style-inlineimage .kt-testimonial-media-wrap {
+  float: left; }
+
+.kt-testimonial-style-inlineimage .kt-testimonial-text-wrap {
+  border: 2px solid #eee;
+  padding: 20px;
+  position: relative;
+  border-radius: 10px;
+  text-align: left; }
+  .kt-testimonial-style-inlineimage .kt-testimonial-text-wrap:after {
+    height: 0;
+    left: 20px;
+    top: 100%;
+    position: absolute;
+    border-top: 14px solid #eee;
+    border-bottom: 14px solid transparent;
+    border-left: 14px solid transparent;
+    border-right: 14px solid transparent;
+    content: '';
+    -webkit-transform: none;
+        -ms-transform: none;
+            transform: none;
+    width: 0; }
+
+.kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap {
+  margin-top: 2px;
+  -ms-flex-pack: start;
+      justify-content: flex-start;
+  padding-left: 60px; }
+  .kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap {
+    text-align: left;
+    display: -ms-flexbox;
+    display: flex; }
+    .kt-testimonial-style-inlineimage .kt-testimonial-meta-wrap .kt-testimonial-meta-name-wrap .kt-testimonial-name-wrap {
+      padding-right: 6px; }
+
+.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-text-wrap {
+  text-align: left; }
+
+.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-media-wrap {
+  float: right; }
+
+.kt-testimonial-style-inlineimage.kt-testimonial-halign-right .kt-testimonial-meta-wrap {
+  padding-left: 0px;
+  padding-right: 60px; }
+
+.kt-testimonial-style-inlineimage .kt-svg-testimonial-global-icon {
+  background: #fff; }
+
+.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-svg-testimonial-global-icon-wrap {
+  margin: -55px 0 10px 0; }
+
+.kt-testimonial-style-inlineimage.kt-testimonials-icon-on .kt-testimonial-item-wrap {
+  padding-top: 55px; }
+
+.kt-testimonial-halign-left .kt-testimonial-item-wrap {
+  text-align: left;
+  margin: 0; }
+  .kt-testimonial-halign-left .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap {
+    text-align: left; }
+
+.kt-testimonial-halign-left .kt-testimonial-meta-wrap {
+  -ms-flex-pack: start;
+      justify-content: flex-start; }
+
+.kt-testimonial-halign-left .kt-testimonial-text-wrap:after {
+  left: 20px;
+  -webkit-transform: none;
+      -ms-transform: none;
+          transform: none; }
+
+.kt-testimonial-halign-right .kt-testimonial-item-wrap {
+  text-align: right;
+  margin-left: auto;
+  margin-right: 0; }
+  .kt-testimonial-halign-right .kt-testimonial-item-wrap .kt-testimonial-meta-name-wrap {
+    text-align: right; }
+
+.kt-testimonial-halign-right .kt-testimonial-meta-wrap {
+  -ms-flex-pack: start;
+      justify-content: flex-start;
+  -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse; }
+
+.kt-testimonial-halign-right .kt-testimonial-media-inner-wrap {
+  margin: 0 0 0 15px; }
+
+.kt-testimonial-halign-right .kt-testimonial-text-wrap:after {
+  left: auto;
+  right: 20px;
+  -webkit-transform: none;
+      -ms-transform: none;
+          transform: none; }
+
+.kt-testimonial-name a {
+  color: inherit; }
+
+.kt-testimonial-occupation a {
+  color: inherit; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for Frontend.
+ */
+.kb-gallery-ul * {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box; }
+
+.wp-block-kadence-advancedgallery {
+  overflow: hidden; }
+
+.wp-block-kadence-advancedgallery:after {
+  clear: both;
+  display: table;
+  content: ''; }
+
+.kb-gallery-ul {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  list-style-type: none;
+  padding: 0;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  margin: -5px; }
+  .kb-gallery-ul .kadence-blocks-gallery-item {
+    position: relative;
+    padding: 5px;
+    list-style-type: none;
+    margin: 0;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box; }
+    .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner {
+      position: relative;
+      margin-bottom: 0; }
+      .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure {
+        margin: 0; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gal-image-radius {
+          position: relative;
+          overflow: hidden;
+          z-index: 1;
+          margin: 0 auto; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain {
+          border: 0;
+          background: transparent;
+          padding: 0;
+          margin: 0;
+          display: block;
+          width: 100%; }
+          .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic {
+            height: 0;
+            position: relative; }
+            .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic img {
+              position: absolute;
+              -ms-flex: 1;
+                  flex: 1;
+              height: 100%;
+              -o-object-fit: cover;
+                 object-fit: cover;
+              width: 100%;
+              top: 0;
+              left: 0; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-square {
+          padding-bottom: 100%; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land43 {
+          padding-bottom: 75%; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land32 {
+          padding-bottom: 66.67%; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land21 {
+          padding-bottom: 50%; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land31 {
+          padding-bottom: 33%; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-land41 {
+          padding-bottom: 25%; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port34 {
+          padding-bottom: 133.33%; }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figure .kb-gallery-image-ratio-port23 {
+          padding-bottom: 150%; }
+      .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        width: 100%;
+        margin: 0;
+        padding: 0; }
+        @supports ((position: -webkit-sticky) or (position: sticky)) {
+          .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner img {
+            width: auto; } }
+      .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption {
+        position: absolute;
+        bottom: 0;
+        max-height: 100%;
+        overflow-y: auto;
+        width: 100%;
+        max-height: 100%;
+        overflow-y: auto;
+        padding: 43px 10px 10px;
+        font-size: 13px;
+        margin-top: 0;
+        color: #f4f4f4;
+        text-align: center;
+        background: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgba(41, 41, 41, 0.5)), to(rgba(41, 41, 41, 0)));
+        background: -webkit-linear-gradient(bottom, rgba(41, 41, 41, 0.5) 0, rgba(41, 41, 41, 0) 100%);
+        background: -o-linear-gradient(bottom, rgba(41, 41, 41, 0.5) 0, rgba(41, 41, 41, 0) 100%);
+        background: linear-gradient(0deg, rgba(41, 41, 41, 0.5) 0, rgba(41, 41, 41, 0) 100%); }
+        .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption img {
+          display: inline; }
+      .kb-gallery-ul .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kadence-blocks-gallery-item-hide-caption figcaption {
+        display: none; }
+  .kb-gallery-ul[data-columns-xs="1"] .kadence-blocks-gallery-item {
+    width: 100%; }
+  .kb-gallery-ul[data-columns-xs="2"] .kadence-blocks-gallery-item {
+    width: 50%; }
+  .kb-gallery-ul[data-columns-xs="3"] .kadence-blocks-gallery-item {
+    width: 33.33333%; }
+  .kb-gallery-ul[data-columns-xs="4"] .kadence-blocks-gallery-item {
+    width: 25%; }
+  .kb-gallery-ul[data-columns-xs="5"] .kadence-blocks-gallery-item {
+    width: 20%; }
+  .kb-gallery-ul[data-columns-xs="6"] .kadence-blocks-gallery-item {
+    width: 16.66667%; }
+  .kb-gallery-ul[data-columns-xs="7"] .kadence-blocks-gallery-item {
+    width: 14.28571%; }
+  .kb-gallery-ul[data-columns-xs="8"] .kadence-blocks-gallery-item {
+    width: 12.5%; }
+  @media (min-width: 543px) {
+    .kb-gallery-ul[data-columns-sm="1"] .kadence-blocks-gallery-item {
+      width: 100%; }
+    .kb-gallery-ul[data-columns-sm="2"] .kadence-blocks-gallery-item {
+      width: 50%; }
+    .kb-gallery-ul[data-columns-sm="3"] .kadence-blocks-gallery-item {
+      width: 33.33333%; }
+    .kb-gallery-ul[data-columns-sm="4"] .kadence-blocks-gallery-item {
+      width: 25%; }
+    .kb-gallery-ul[data-columns-sm="5"] .kadence-blocks-gallery-item {
+      width: 20%; }
+    .kb-gallery-ul[data-columns-sm="6"] .kadence-blocks-gallery-item {
+      width: 16.66667%; }
+    .kb-gallery-ul[data-columns-sm="7"] .kadence-blocks-gallery-item {
+      width: 14.28571%; }
+    .kb-gallery-ul[data-columns-sm="8"] .kadence-blocks-gallery-item {
+      width: 12.5%; } }
+  @media (min-width: 768px) {
+    .kb-gallery-ul[data-columns-md="1"] .kadence-blocks-gallery-item {
+      width: 100%; }
+    .kb-gallery-ul[data-columns-md="2"] .kadence-blocks-gallery-item {
+      width: 50%; }
+    .kb-gallery-ul[data-columns-md="3"] .kadence-blocks-gallery-item {
+      width: 33.33333%; }
+    .kb-gallery-ul[data-columns-md="4"] .kadence-blocks-gallery-item {
+      width: 25%; }
+    .kb-gallery-ul[data-columns-md="5"] .kadence-blocks-gallery-item {
+      width: 20%; }
+    .kb-gallery-ul[data-columns-md="6"] .kadence-blocks-gallery-item {
+      width: 16.66667%; }
+    .kb-gallery-ul[data-columns-md="7"] .kadence-blocks-gallery-item {
+      width: 14.28571%; }
+    .kb-gallery-ul[data-columns-md="8"] .kadence-blocks-gallery-item {
+      width: 12.5%; } }
+  @media (min-width: 992px) {
+    .kb-gallery-ul[data-columns-lg="1"] .kadence-blocks-gallery-item {
+      width: 100%; }
+    .kb-gallery-ul[data-columns-lg="2"] .kadence-blocks-gallery-item {
+      width: 50%; }
+    .kb-gallery-ul[data-columns-lg="3"] .kadence-blocks-gallery-item {
+      width: 33.33333%; }
+    .kb-gallery-ul[data-columns-lg="4"] .kadence-blocks-gallery-item {
+      width: 25%; }
+    .kb-gallery-ul[data-columns-lg="5"] .kadence-blocks-gallery-item {
+      width: 20%; }
+    .kb-gallery-ul[data-columns-lg="6"] .kadence-blocks-gallery-item {
+      width: 16.66667%; }
+    .kb-gallery-ul[data-columns-lg="7"] .kadence-blocks-gallery-item {
+      width: 14.28571%; }
+    .kb-gallery-ul[data-columns-lg="8"] .kadence-blocks-gallery-item {
+      width: 12.5%; } }
+  @media (min-width: 1200px) {
+    .kb-gallery-ul[data-columns-xl="1"] .kadence-blocks-gallery-item {
+      width: 100%; }
+    .kb-gallery-ul[data-columns-xl="2"] .kadence-blocks-gallery-item {
+      width: 50%; }
+    .kb-gallery-ul[data-columns-xl="3"] .kadence-blocks-gallery-item {
+      width: 33.33333%; }
+    .kb-gallery-ul[data-columns-xl="4"] .kadence-blocks-gallery-item {
+      width: 25%; }
+    .kb-gallery-ul[data-columns-xl="5"] .kadence-blocks-gallery-item {
+      width: 20%; }
+    .kb-gallery-ul[data-columns-xl="6"] .kadence-blocks-gallery-item {
+      width: 16.66667%; }
+    .kb-gallery-ul[data-columns-xl="7"] .kadence-blocks-gallery-item {
+      width: 14.28571%; }
+    .kb-gallery-ul[data-columns-xl="8"] .kadence-blocks-gallery-item {
+      width: 12.5%; } }
+  @media (min-width: 1500px) {
+    .kb-gallery-ul[data-columns-xxl="1"] .kadence-blocks-gallery-item {
+      width: 100%; }
+    .kb-gallery-ul[data-columns-xxl="2"] .kadence-blocks-gallery-item {
+      width: 50%; }
+    .kb-gallery-ul[data-columns-xxl="3"] .kadence-blocks-gallery-item {
+      width: 33.33333%; }
+    .kb-gallery-ul[data-columns-xxl="4"] .kadence-blocks-gallery-item {
+      width: 25%; }
+    .kb-gallery-ul[data-columns-xxl="5"] .kadence-blocks-gallery-item {
+      width: 20%; }
+    .kb-gallery-ul[data-columns-xxl="6"] .kadence-blocks-gallery-item {
+      width: 16.66667%; }
+    .kb-gallery-ul[data-columns-xxl="7"] .kadence-blocks-gallery-item {
+      width: 14.28571%; }
+    .kb-gallery-ul[data-columns-xxl="8"] .kadence-blocks-gallery-item {
+      width: 12.5%; } }
+
+.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item figcaption {
+  opacity: 0;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  -o-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out; }
+
+.kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item:hover figcaption, .kb-gallery-caption-style-bottom-hover .kadence-blocks-gallery-item .is-selected figcaption {
+  opacity: 1; }
+
+.kb-gallery-ul.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  padding: 10px;
+  margin: 0;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  -o-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
+  background: rgba(0, 0, 0, 0.5); }
+
+.kb-gallery-ul.kb-gallery-caption-style-cover-hover .kadence-blocks-gallery-item:hover figcaption {
+  opacity: 1; }
+
+.wp-block[data-type="kadence/advancedgallery"] .kb-gallery-ul.kb-gallery-type-carousel, .wp-block[data-type="kadence/advancedgallery"] .kb-gallery-ul.kb-gallery-type-fluidcarousel, .wp-block[data-type="kadence/advancedgallery"] .kb-gallery-ul.kb-gallery-type-slider {
+  margin: 0; }
+
+.kb-gallery-ul.kb-gallery-type-carousel, .kb-gallery-ul.kb-gallery-type-slider {
+  display: block;
+  margin: 0; }
+  .kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider, .kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-slider {
+    margin: 0 -5px;
+    -webkit-user-select: auto;
+       -moz-user-select: auto;
+        -ms-user-select: auto;
+            user-select: auto;
+    -ms-touch-action: auto;
+        touch-action: auto; }
+    .kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-slider .kb-slide-item, .kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-slider .kb-slide-item {
+      padding: 4px 5px; }
+  .kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-prev, .kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-prev {
+    left: 5px; }
+  .kb-gallery-ul.kb-gallery-type-carousel .kt-blocks-carousel .slick-next, .kb-gallery-ul.kb-gallery-type-slider .kt-blocks-carousel .slick-next {
+    right: 5px; }
+  .kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item, .kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item {
+    padding: 0 !important; }
+
+.kb-gallery-ul.kb-gallery-type-fluidcarousel {
+  display: block;
+  margin: 0; }
+  .kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .kt-blocks-carousel-init {
+    margin: 0;
+    -webkit-user-select: auto;
+       -moz-user-select: auto;
+        -ms-user-select: auto;
+            user-select: auto;
+    -ms-touch-action: auto;
+        touch-action: auto; }
+    .kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .kt-blocks-carousel-init .kb-slide-item {
+      padding: 4px 5px; }
+    .kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .kt-blocks-carousel-init.kb-carousel-mode-align-left .kb-slide-item {
+      padding: 4px 10px 4px 0; }
+  .kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-prev {
+    left: 0px; }
+  .kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel .slick-next {
+    right: 0px; }
+  .kb-gallery-ul.kb-gallery-type-fluidcarousel .kadence-blocks-gallery-item {
+    padding: 0 !important; }
+
+.kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit {
+  padding-bottom: 100%; }
+  .kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img {
+    -o-object-fit: contain;
+       object-fit: contain; }
+
+.kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit {
+  padding-bottom: 66.67%; }
+  .kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner .kb-gallery-image-contain.kadence-blocks-gallery-intrinsic.kb-gallery-image-ratio-inherit img {
+    -o-object-fit: contain;
+       object-fit: contain; }
+
+.kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel figure .kb-gal-image-radius {
+  height: 300px;
+  width: auto;
+  margin: 0 auto; }
+  .kb-gallery-ul.kb-gallery-type-fluidcarousel .kt-blocks-carousel figure .kb-gal-image-radius img {
+    height: 300px;
+    width: auto;
+    -ms-flex: 1;
+        flex: 1;
+    -o-object-fit: cover;
+       object-fit: cover; }
+
+.kb-gallery-type-fluidcarousel.kb-gallery-caption-style-below .kb-gallery-item-link, .kb-gallery-type-fluidcarousel.kb-gallery-caption-style-below figure:not(.kb-gallery-item-has-link) {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column; }
+
+.kb-gallery-caption-style-below .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption.kadence-blocks-gallery-item__caption {
+  padding: 10px;
+  margin-top: 0;
+  background: rgba(0, 0, 0, 0.5);
+  position: static; }
+
+.kb-gallery-type-carousel .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after, .kb-gallery-type-slider .kb-gallery-image-ratio-inherit.kb-gallery-image-contain:after {
+  display: none; }
+
+.kb-gallery-ul.kb-gallery-type-carousel .kadence-blocks-gallery-item .kb-has-image-ratio-inherit .kb-gal-image-radius, .kb-gallery-ul.kb-gallery-type-slider .kadence-blocks-gallery-item .kb-has-image-ratio-inherit .kb-gal-image-radius {
+  border-radius: 0; }
+
+.kb-gallery-filter-vintage .kb-gallery-image-contain:after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  -webkit-box-shadow: inset 0 0 100px rgba(0, 0, 20, 0.4), inset 0 5px 15px rgba(0, 0, 0, 0.1);
+          box-shadow: inset 0 0 100px rgba(0, 0, 20, 0.4), inset 0 5px 15px rgba(0, 0, 0, 0.1);
+  background: -webkit-linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), -webkit-linear-gradient(70deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%);
+  background: -o-linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), -o-linear-gradient(70deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%);
+  background: linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), linear-gradient(20deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%); }
+
+.kb-gallery-filter-vintage .kb-gallery-image-contain img {
+  -webkit-filter: sepia(0.2) brightness(1.1) contrast(1.3);
+          filter: sepia(0.2) brightness(1.1) contrast(1.3); }
+
+.kb-gal-light-filter-vintage .mfp-figure figure::before {
+  -webkit-box-shadow: inset 0 0 100px rgba(0, 0, 20, 0.4), inset 0 5px 15px rgba(0, 0, 0, 0.1);
+          box-shadow: inset 0 0 100px rgba(0, 0, 20, 0.4), inset 0 5px 15px rgba(0, 0, 0, 0.1);
+  background: -webkit-linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), -webkit-linear-gradient(70deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%);
+  background: -o-linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), -o-linear-gradient(70deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%);
+  background: linear-gradient(top, rgba(255, 145, 0, 0.2) 0%, rgba(255, 230, 48, 0.2) 60%), linear-gradient(20deg, rgba(255, 0, 0, 0.2) 0%, rgba(255, 0, 0, 0) 35%);
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 40px;
+  bottom: 40px;
+  z-index: 1; }
+
+.kb-gal-light-filter-vintage .mfp-figure figure img {
+  -webkit-filter: sepia(0.2) brightness(1.1) contrast(1.3);
+          filter: sepia(0.2) brightness(1.1) contrast(1.3); }
+
+.kb-gallery-filter-grayscale .kb-gallery-image-contain img, .kb-gal-light-filter-grayscale .mfp-figure img {
+  -webkit-filter: grayscale(1);
+          filter: grayscale(1); }
+
+.kb-gallery-filter-sepia .kb-gallery-image-contain img, .kb-gal-light-filter-sepia .mfp-figure img {
+  -webkit-filter: sepia(0.5);
+          filter: sepia(0.5); }
+
+.kb-gallery-filter-saturation .kb-gallery-image-contain img, .kb-gal-light-filter-saturation .mfp-figure img {
+  -webkit-filter: saturate(1.6);
+          filter: saturate(1.6); }
+
+.kb-gallery-filter-earlybird .kb-gallery-image-contain::after {
+  background: -webkit-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  background: -o-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  background: radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  mix-blend-mode: overlay;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0; }
+
+.kb-gallery-filter-earlybird .kb-gallery-image-contain img {
+  -webkit-filter: contrast(0.9) sepia(0.2);
+          filter: contrast(0.9) sepia(0.2); }
+
+.kb-gal-light-filter-earlybird .mfp-figure figure::before {
+  background: -webkit-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  background: -o-radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  background: radial-gradient(circle, #d0ba8e 20%, #360309 85%, #1d0210 100%);
+  mix-blend-mode: overlay;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 40px;
+  bottom: 40px;
+  z-index: 1; }
+
+.kb-gal-light-filter-earlybird .mfp-figure figure img {
+  -webkit-filter: contrast(0.9) sepia(0.2);
+          filter: contrast(0.9) sepia(0.2); }
+
+.kb-gallery-filter-toaster .kb-gallery-image-contain::after {
+  background: -webkit-radial-gradient(circle, #804e0f, #3b003b);
+  background: -o-radial-gradient(circle, #804e0f, #3b003b);
+  background: radial-gradient(circle, #804e0f, #3b003b);
+  mix-blend-mode: screen;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0; }
+
+.kb-gallery-filter-toaster .kb-gallery-image-contain img {
+  -webkit-filter: contrast(1.5) brightness(0.9);
+          filter: contrast(1.5) brightness(0.9); }
+
+.kb-gal-light-filter-toaster .mfp-figure figure::before {
+  background: -webkit-radial-gradient(circle, #804e0f, #3b003b);
+  background: -o-radial-gradient(circle, #804e0f, #3b003b);
+  background: radial-gradient(circle, #804e0f, #3b003b);
+  mix-blend-mode: screen;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 40px;
+  bottom: 40px;
+  z-index: 1; }
+
+.kb-gal-light-filter-toaster .mfp-figure figure img {
+  -webkit-filter: contrast(1.5) brightness(0.9);
+          filter: contrast(1.5) brightness(0.9); }
+
+.kb-gallery-filter-mayfair .kb-gallery-image-contain::after {
+  background: -webkit-radial-gradient(40% 40%, circle, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  background: -o-radial-gradient(40% 40%, circle, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  mix-blend-mode: overlay;
+  opacity: .4;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0; }
+
+.kb-gallery-filter-mayfair .kb-gallery-image-contain img {
+  -webkit-filter: contrast(1.1) saturate(1.1);
+          filter: contrast(1.1) saturate(1.1); }
+
+.kb-gal-light-filter-mayfair .mfp-figure figure::before {
+  background: -webkit-radial-gradient(40% 40%, circle, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  background: -o-radial-gradient(40% 40%, circle, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.8), rgba(255, 200, 200, 0.6), #111 60%);
+  mix-blend-mode: overlay;
+  opacity: .4;
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 40px;
+  bottom: 40px;
+  z-index: 1; }
+
+.kb-gal-light-filter-mayfair .mfp-figure figure img {
+  -webkit-filter: contrast(1.1) saturate(1.1);
+          filter: contrast(1.1) saturate(1.1); }
+
+.kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item {
+  display: none; }
+  .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item:nth-child(-n+3) {
+    width: 33.33%;
+    display: block;
+    float: left; }
+
+.kt-blocks-carousel-init:after {
+  clear: both;
+  display: table;
+  content: ''; }
+
+.kb-blocks-fluid-carousel:not(.slick-initialized) .kb-slide-item {
+  max-width: 80%;
+  margin: 0 auto;
+  display: none; }
+  .kb-blocks-fluid-carousel:not(.slick-initialized) .kb-slide-item:nth-child(-n+1) {
+    display: block; }
+
+.kt-blocks-carousel-init:not(.slick-initialized) {
+  margin: 0 -5px; }
+  @media (max-width: 543px) {
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="1"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="1"] .kb-slide-item:nth-child(-n+1) {
+        width: 100%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="2"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-ss="2"] .kb-slide-item:nth-child(-n+2) {
+        width: 50%;
+        display: block;
+        float: left; } }
+  @media (min-width: 544px) and (max-width: 767px) {
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="1"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="1"] .kb-slide-item:nth-child(-n+1) {
+        width: 100%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="2"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="2"] .kb-slide-item:nth-child(-n+2) {
+        width: 50%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="3"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="3"] .kb-slide-item:nth-child(-n+3) {
+        width: 33.33333%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="4"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xs="4"] .kb-slide-item:nth-child(-n+4) {
+        width: 25%;
+        display: block;
+        float: left; } }
+  @media (min-width: 768px) and (max-width: 991px) {
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="1"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="1"] .kb-slide-item:nth-child(-n+1) {
+        width: 100%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="2"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="2"] .kb-slide-item:nth-child(-n+2) {
+        width: 50%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="3"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="3"] .kb-slide-item:nth-child(-n+3) {
+        width: 33.33333%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="4"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="4"] .kb-slide-item:nth-child(-n+4) {
+        width: 25%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="5"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="5"] .kb-slide-item:nth-child(-n+5) {
+        width: 20%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="6"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="6"] .kb-slide-item:nth-child(-n+6) {
+        width: 16.66667%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="7"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="7"] .kb-slide-item:nth-child(-n+7) {
+        width: 14.28571%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="8"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-sm="8"] .kb-slide-item:nth-child(-n+8) {
+        width: 12.5%;
+        display: block;
+        float: left; } }
+  @media (min-width: 992px) and (max-width: 1199px) {
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="1"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="1"] .kb-slide-item:nth-child(-n+1) {
+        width: 100%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="2"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="2"] .kb-slide-item:nth-child(-n+2) {
+        width: 50%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="3"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="3"] .kb-slide-item:nth-child(-n+3) {
+        width: 33.33333%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="4"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="4"] .kb-slide-item:nth-child(-n+4) {
+        width: 25%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="5"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="5"] .kb-slide-item:nth-child(-n+5) {
+        width: 20%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="6"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="6"] .kb-slide-item:nth-child(-n+6) {
+        width: 16.66667%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="7"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="7"] .kb-slide-item:nth-child(-n+7) {
+        width: 14.28571%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="8"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-md="8"] .kb-slide-item:nth-child(-n+8) {
+        width: 12.5%;
+        display: block;
+        float: left; } }
+  @media (min-width: 1200px) and (max-width: 1499px) {
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="1"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="1"] .kb-slide-item:nth-child(-n+1) {
+        width: 100%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="2"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="2"] .kb-slide-item:nth-child(-n+2) {
+        width: 50%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="3"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="3"] .kb-slide-item:nth-child(-n+3) {
+        width: 33.33333%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="4"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="4"] .kb-slide-item:nth-child(-n+4) {
+        width: 25%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="5"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="5"] .kb-slide-item:nth-child(-n+5) {
+        width: 20%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="6"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="6"] .kb-slide-item:nth-child(-n+6) {
+        width: 16.66667%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="7"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="7"] .kb-slide-item:nth-child(-n+7) {
+        width: 14.28571%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="8"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xl="8"] .kb-slide-item:nth-child(-n+8) {
+        width: 12.5%;
+        display: block;
+        float: left; } }
+  @media (min-width: 1500px) {
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="1"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="1"] .kb-slide-item:nth-child(-n+1) {
+        width: 100%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="2"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="2"] .kb-slide-item:nth-child(-n+2) {
+        width: 50%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="3"] .kb-slide-item:nth-child(-n+3) {
+        width: 33.33333%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="4"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="4"] .kb-slide-item:nth-child(-n+4) {
+        width: 25%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="5"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="5"] .kb-slide-item:nth-child(-n+5) {
+        width: 20%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="6"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="6"] .kb-slide-item:nth-child(-n+6) {
+        width: 16.66667%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="7"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="7"] .kb-slide-item:nth-child(-n+7) {
+        width: 14.28571%;
+        display: block;
+        float: left; }
+    .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="8"] .kb-slide-item {
+      display: none; }
+      .kt-blocks-carousel-init:not(.slick-initialized)[data-columns-xxl="8"] .kb-slide-item:nth-child(-n+8) {
+        width: 12.5%;
+        display: block;
+        float: left; } }
+  .kt-blocks-carousel-init:not(.slick-initialized) .kb-slide-item {
+    padding: 4px 5px; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1269,7 +1269,7 @@
         "component-emitter": "^1.2.1",
         "define-property": "^1.0.0",
         "isobject": "^3.0.1",
-        "mixin-deep": "^1.3.2",
+        "mixin-deep": "^1.2.0",
         "pascalcase": "^0.1.1"
       },
       "dependencies": {
@@ -1305,6 +1305,23 @@
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        },
+        "mixin-deep": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+          "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
           }
         }
       }
@@ -4697,25 +4714,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-    },
-    "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-      "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
     },
     "mixin-object": {
       "version": "2.0.1",

--- a/src/blocks/column/block.js
+++ b/src/blocks/column/block.js
@@ -176,6 +176,8 @@ registerBlockType( 'kadence/column', {
 		ktanimateadd: true,
 		ktanimatepreview: true,
 		ktanimateswipe: true,
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator: true,
 	},
 	edit,
 

--- a/src/blocks/row-layout/block.js
+++ b/src/blocks/row-layout/block.js
@@ -61,6 +61,8 @@ registerBlockType( 'kadence/rowlayout', {
 	],
 	supports: {
 		anchor: true,
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator: true,
 	},
 	attributes,
 	getEditWrapperProps( { blockAlignment } ) {


### PR DESCRIPTION
Hi,

I've just recently added Block Navigation toolbar on my [EditorsKit](https://wordpress.org/plugins/block-options/) plugin. I think this will be of great help on user navigation when both plugins are activated. The toolbar will only be shown on blocks with multiple inner blocks capability.

- [x] Row
- [x] Column

 
Here's how it works:
![Screen Capture on 2019-09-27 at 12-23-16](https://user-images.githubusercontent.com/3365507/65742268-0de8a980-e122-11e9-9b6a-f6a7eb7f09ad.gif)

Let me know your thoughts.

Thanks,
Jeffrey