### PR TITLE
feat($general): support themes with variables in their color palette

### DIFF
--- a/src/hex-to-rgba.js
+++ b/src/hex-to-rgba.js
@@ -8,6 +8,16 @@ export default function hexToRGBA( hex, alpha ) {
 	if ( null === hex ) {
 		return '';
 	}
+
+	/**
+	 * Detect CSS variables in form of var(--color) and get their current
+	 * values from the :root selector.
+	 */
+	if ( hexColor.indexOf( 'var(' ) > -1 ) {
+		hexColor = window.getComputedStyle( document.documentElement )
+			.getPropertyValue( hexColor.replace( 'var(', '' ).replace( ')', '' ) ) || '#fff'
+	}
+
 	hex = hex.replace( '#', '' );
 	const r = parseInt( hex.length === 3 ? hex.slice( 0, 1 ).repeat( 2 ) : hex.slice( 0, 2 ), 16 );
 	const g = parseInt( hex.length === 3 ? hex.slice( 1, 2 ).repeat( 2 ) : hex.slice( 2, 4 ), 16 );


### PR DESCRIPTION
Solves the problem of applying the opacity onto the colors from the Gutenberg color palette, when the color palette contains a CSS Custom Property. It expects the css variable to be defined on the `:root` element.

How to test:

Apply this palette to Gutenberg:

```php
add_theme_support( 'editor-color-palette', [
    [
        'name' => __( 'Palette Color 1', 'blocksy' ),
        'slug' => 'palette-color-1',
        'color' => 'var(--paletteColor1)',
    ],

    [
        'name' => __( 'Palette Color 2', 'blocksy' ),
        'slug' => 'palette-color-2',
        'color' => 'var(--paletteColor2)',
    ],

    [
        'name' => __( 'Palette Color 3', 'blocksy' ),
        'slug' => 'palette-color-3',
        'color' => 'var(--paletteColor3)',
    ],

    [
        'name' => __( 'Palette Color 4', 'blocksy' ),
        'slug' => 'palette-color-4',
        'color' => 'var(--paletteColor4)',
    ],

    [
        'name' => __( 'Palette Color 5', 'blocksy' ),
        'slug' => 'palette-color-5',
        'color' => 'var(--paletteColor5)',
    ]
]);
```

With that in place, define these CSS variables from:

```css
:root {
  --paletteColor1: red;
  --paletteColor2: green;
  --paletteColor3: blue;
  --paletteColor4: pink;
  --paletteColor5: black;
}
```

With this in place, `hexToRgba()` will be able to apply the opacity correctly. I'll be happy to change the implementation if this somehow doesn't fit the project's guidelines and rules.

---

This approach for the Color Palette is used in [Blocksy](https://wordpress.org/themes/blocksy/) and there were no problems with this up until now. Hope this fix could be included in Kadence Blocks for a better compatibility between the two tools.

A similar PR was applied on Stackable blocks and runs with success so far: https://github.com/gambitph/Stackable/pull/706