### PR TITLE
Include image.style.build.css in head tag instead of end of body tag

### DIFF
--- a/dist/class-kadence-blocks-frontend.php
+++ b/dist/class-kadence-blocks-frontend.php
@@ -1762,6 +1762,12 @@ class Kadence_Blocks_Frontend {
 							$this->blocks_tabs_scripts_gfonts( $blockattr );
 						}
 					}
+					if ( 'kadence/image' === $block['blockName'] ) {
+						if ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) {
+							$blockattr = $block['attrs'];
+							$this->render_image_css_head( $blockattr );
+						}
+					}
 					if ( 'kadence/infobox' === $block['blockName'] ) {
 						if ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) {
 							$blockattr = $block['attrs'];


### PR DESCRIPTION
Wasn't calling `render_image_css_head`