### PR TITLE
Add option to send remote IP using a hidden field on (email) forms.

### DIFF
--- a/dist/form-ajax.php
+++ b/dist/form-ajax.php
@@ -191,6 +191,7 @@ class KB_Ajax_Form {
 							$refer_id = is_object( $post ) ? $post->ID : url_to_postid( wp_get_referer() );
 							$fields[ $key ]['value'] = str_replace( '{page_title}', get_the_title( $refer_id ), $fields[ $key ]['value'] );
 							$fields[ $key ]['value'] = str_replace( '{page_url}', wp_get_referer(), $fields[ $key ]['value'] );
+							$fields[ $key ]['value'] = str_replace( '{remoteip}', $_SERVER['REMOTE_ADDR'], $fields[ $key ]['value']);
 						}
 						unset( $_POST[ 'kb_field_' . $key ] );
 					}


### PR DESCRIPTION
A small and simple implementation which makes it possible to send the remote IP of the form submitter along with the form/email message to the website owner etc.
It was one of the few features I missed in the  Kadence Form Block, which does however make it (alot) easier to block IP's etc from the site when abuse is detected.

I have seen this implemented in several other 'form plugins' for Wordpress, however with this small 'feature' implemented in the Kadence Form Block it would not be needed at all for me to use any other plugin :)