### PR TITLE
Image block support for Imagify picture tags

### DIFF
--- a/dist/class-kadence-blocks-frontend.php
+++ b/dist/class-kadence-blocks-frontend.php
@@ -6454,7 +6454,7 @@ class Kadence_Blocks_Frontend {
 				$css->add_property( 'max-width', $attr['imgMaxWidth'] . 'px' );
 			}
 		}
-		$css->set_selector( '.kb-image' . $unique_id . ' .kb-img' );
+		$css->set_selector( '.kb-image' . $unique_id . ' .kb-img, .kb-image' . $unique_id . ' .kb-img img' );
 		// Padding
 		foreach(['Desktop', 'Tablet', 'Mobile'] as $breakpoint) {
 			$css->start_media_query( $media_query[ strtolower($breakpoint) ] );

--- a/dist/class-kadence-blocks-frontend.php
+++ b/dist/class-kadence-blocks-frontend.php
@@ -6454,7 +6454,7 @@ class Kadence_Blocks_Frontend {
 				$css->add_property( 'max-width', $attr['imgMaxWidth'] . 'px' );
 			}
 		}
-		$css->set_selector( '.kb-image' . $unique_id . ' .kb-img, .kb-image' . $unique_id . ' .kb-img img' );
+		$css->set_selector( '.kb-image' . $unique_id . ' img.kb-img, .kb-image' . $unique_id . ' .kb-img img' );
 		// Padding
 		foreach(['Desktop', 'Tablet', 'Mobile'] as $breakpoint) {
 			$css->start_media_query( $media_query[ strtolower($breakpoint) ] );


### PR DESCRIPTION
Imagify replaces the `img` tag with a `picture` tag that has the classes of the previous img tag. Some attributes aren't applied properly since they are currently being applied to the `picture` tag in the current setup