### PR TITLE
[Lottie] Add option to only play animation when in viewport

### DIFF
--- a/dist/class-kadence-blocks-frontend.php
+++ b/dist/class-kadence-blocks-frontend.php
@@ -1134,9 +1134,15 @@ class Kadence_Blocks_Frontend {
 				}
 			}
 			// Include lottie interactive if using scroll animation.
-			if ( isset( $attributes['onlyPlayOnScroll'] ) && $attributes['onlyPlayOnScroll'] === true ) {
+			if ( isset( $attributes['onlyPlayOnScroll'] ) && $attributes['onlyPlayOnScroll'] === true || isset($attributes['waitUntilInView']) && $attributes['waitUntilInView'] === true ) {
 				if ( ! wp_script_is( 'kadence-blocks-lottieinteractivity-js', 'enqueued' ) ) {
 					wp_enqueue_script( 'kadence-blocks-lottieinteractivity-js' );
+				}
+
+				if( isset( $attributes['onlyPlayOnScroll'] ) && $attributes['onlyPlayOnScroll'] === true ){
+					$play_type = 'seek';
+				} else {
+					$play_type = 'play';
 				}
 
 				$content = $content . "
@@ -1149,7 +1155,7 @@ class Kadence_Blocks_Frontend {
 								actions: [
 									{
 									visibility: [0,1],
-									type: 'seek',
+									type: '" . $play_type . "',
 									frames: [" . ( ! empty( $attributes['startFrame'] ) ? $attributes['startFrame'] : '0' ) . ", " . ( ! empty( $attributes['endFrame'] ) ? $attributes['endFrame'] : '100' ) . "],
 									},
 								],

--- a/dist/class-kadence-blocks-frontend.php
+++ b/dist/class-kadence-blocks-frontend.php
@@ -1141,8 +1141,10 @@ class Kadence_Blocks_Frontend {
 
 				if( isset( $attributes['onlyPlayOnScroll'] ) && $attributes['onlyPlayOnScroll'] === true ){
 					$play_type = 'seek';
+					$frames = "frames: [" . ( ! empty( $attributes['startFrame'] ) ? $attributes['startFrame'] : '0' ) . ", " . ( ! empty( $attributes['endFrame'] ) ? $attributes['endFrame'] : '100' ) . "]";
 				} else {
 					$play_type = 'play';
+					$frames = '';
 				}
 
 				$content = $content . "
@@ -1154,9 +1156,9 @@ class Kadence_Blocks_Frontend {
 								player: '#" . $player_style_id . "',
 								actions: [
 									{
-									visibility: [0,1],
+									visibility: [0,1.0],
 									type: '" . $play_type . "',
-									frames: [" . ( ! empty( $attributes['startFrame'] ) ? $attributes['startFrame'] : '0' ) . ", " . ( ! empty( $attributes['endFrame'] ) ? $attributes['endFrame'] : '100' ) . "],
+									$frames
 									},
 								],
 							});

--- a/src/blocks/lottie/block.json
+++ b/src/blocks/lottie/block.json
@@ -46,6 +46,10 @@
 	  "type": "boolean",
 	  "default": false
 	},
+	"waitUntilInView": {
+	  "type": "boolean",
+	  "default": false
+	},
 	"startFrame": {
 		"type": "number",
 		"default": "0"

--- a/src/blocks/lottie/edit.js
+++ b/src/blocks/lottie/edit.js
@@ -333,7 +333,7 @@ export function Edit( {
 						label={ __( 'Autoplay', 'kadence-blocks' ) }
 						checked={ autoplay }
 						onChange={ ( value ) => {
-							setAttributes( { autoplay: value, onlyPlayOnHover: (value ? false : onlyPlayOnHover), onlyPlayOnScroll: (value ? false : onlyPlayOnScroll) } );
+							setAttributes( { autoplay: value, waitUntilInView: ( value ? waitUntilInView : false ), onlyPlayOnHover: (value ? false : onlyPlayOnHover), onlyPlayOnScroll: (value ? false : onlyPlayOnScroll) } );
 							setRerenderKey( Math.random() );
 						}}
 					/>
@@ -387,7 +387,7 @@ export function Edit( {
 							label={ __( 'Don\'t play until in view', 'kadence-blocks' ) }
 							help={ __('Prevent playback from starting until animation is in view', 'kadence-blocks') }
 							checked={ waitUntilInView }
-							onChange={ (value) => { setAttributes( { waitUntilInView: value } ) } }
+							onChange={ (value) => { setAttributes( { waitUntilInView: value, autoplay: ( value ? true : autoplay ) } ) } }
 							/>
 						</div>
 					}

--- a/src/blocks/lottie/edit.js
+++ b/src/blocks/lottie/edit.js
@@ -62,6 +62,7 @@ export function Edit( {
 		loop,
 		onlyPlayOnHover,
 		onlyPlayOnScroll,
+		waitUntilInView,
 		bouncePlayback,
 		playbackSpeed,
 		loopLimit,
@@ -353,7 +354,8 @@ export function Edit( {
 							setRerenderKey( Math.random() );
 						} }
 					/>
-					{ onlyPlayOnScroll && (
+
+					{ onlyPlayOnScroll ?
 						<>
 							<div style={ { marginBottom: '15px'} }>
 								<NumberControl
@@ -379,7 +381,17 @@ export function Edit( {
 								/>
 							</div>
 						</>
-					) }
+					 :
+						<div style={ { marginBottom: '15px'} }>
+							<ToggleControl
+							label={ __( 'Don\'t play until in view', 'kadence-blocks' ) }
+							help={ __('Prevent playback from starting until animation is in view', 'kadence-blocks') }
+							checked={ waitUntilInView }
+							onChange={ (value) => { setAttributes( { waitUntilInView: value } ) } }
+							/>
+						</div>
+					}
+
 					<RangeControl
 						label={ __( 'Playback Speed', 'kadence-blocks' ) }
 						value={ playbackSpeed }


### PR DESCRIPTION
Regarding playing on scrolling: the Lottie interactive docs and my testing 
> The scrolling effect is activated as soon as the animation enters the view port

I've set this option to only display when "only play on scroll" is disabled, since that is already the case when enabled. 

Main benefits I'm seeing are the animation is always at the beginning of the loop when scrolling into frame and is users only want one loop 