### PR TITLE
[Form] Fix inaccurate preview of responsive changes 

### DIFF
--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -712,6 +712,14 @@ class KadenceForm extends Component {
 		const previewStyleLineHeight = getPreviewSize( this.props.getPreviewDevice, style[ 0 ].lineHeight[0], style[ 0 ].lineHeight[1], style[ 0 ].lineHeight[2] );
 		const previewStyleLineHeightType = style[ 0 ].lineType;
 
+		const previewLabelFontSize = getPreviewSize(this.props.getPreviewDevice, labelFont[ 0 ].size[0], labelFont[ 0 ].size[1], labelFont[ 0 ].size[2] );
+		const previewLabelFontSizeType = labelFont[ 0 ].sizeType;
+		const previewLabelLineHeight = getPreviewSize(this.props.getPreviewDevice, labelFont[ 0 ].lineHeight[0], labelFont[ 0 ].lineHeight[1], labelFont[ 0 ].lineHeight[2] );
+		const previewLabelLineHeightType = labelFont[ 0 ].lineType;
+
+		const previewSubmitFontSize = getPreviewSize(this.props.getPreviewDevice, submitFont[ 0 ].size[0], submitFont[ 0 ].size[1], submitFont[ 0 ].size[2] );
+		const previewSubmitFontSizeType = submitFont[ 0 ].sizeType;
+
 		const previewRowGap = getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].rowGap && '' !== style[ 0 ].rowGap ? style[ 0 ].rowGap + 'px' : '' ), ( undefined !== style[ 0 ].tabletRowGap && '' !== style[ 0 ].tabletRowGap ? style[ 0 ].tabletRowGap + 'px' : '' ), ( undefined !== style[ 0 ].mobileRowGap && '' !== style[ 0 ].mobileRowGap ? style[ 0 ].mobileRowGap + 'px' : '' ) );
 		const previewGutter = getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].gutter && '' !== style[ 0 ].gutter ? style[ 0 ].gutter : '' ), ( undefined !== style[ 0 ].tabletGutter && '' !== style[ 0 ].tabletGutter ? style[ 0 ].tabletGutter : '' ), ( undefined !== style[ 0 ].mobileGutter && '' !== style[ 0 ].mobileGutter ? style[ 0 ].mobileGutter : '' ) );
 		const containerMarginMin = ( containerMarginType === 'em' || containerMarginType === 'rem' ? -2 : -200 );
@@ -1294,8 +1302,8 @@ class KadenceForm extends Component {
 								fontWeight: labelFont[ 0 ].weight,
 								fontStyle: labelFont[ 0 ].style,
 								color: KadenceColorOutput( labelFont[ 0 ].color ),
-								fontSize: labelFont[ 0 ].size[ 0 ] + labelFont[ 0 ].sizeType,
-								lineHeight: ( labelFont[ 0 ].lineHeight && labelFont[ 0 ].lineHeight[ 0 ] ? labelFont[ 0 ].lineHeight[ 0 ] + labelFont[ 0 ].lineType : undefined ),
+								fontSize: previewLabelFontSize + previewLabelFontSizeType,
+								lineHeight: previewLabelLineHeight + previewLabelLineHeightType,
 								letterSpacing: labelFont[ 0 ].letterSpacing + 'px',
 								textTransform: ( labelFont[ 0 ].textTransform ? labelFont[ 0 ].textTransform  : undefined ),
 								fontFamily: ( labelFont[ 0 ].family ? labelFont[ 0 ].family : undefined ),
@@ -1317,8 +1325,8 @@ class KadenceForm extends Component {
 									fontWeight: labelFont[ 0 ].weight,
 									fontStyle: labelFont[ 0 ].style,
 									color: KadenceColorOutput( labelFont[ 0 ].color ),
-									fontSize: labelFont[ 0 ].size[ 0 ] + labelFont[ 0 ].sizeType,
-									lineHeight: ( labelFont[ 0 ].lineHeight && labelFont[ 0 ].lineHeight[ 0 ] ? labelFont[ 0 ].lineHeight[ 0 ] + labelFont[ 0 ].lineType : undefined ),
+									fontSize: previewLabelFontSize + previewLabelFontSizeType,
+									lineHeight: previewLabelLineHeight + previewLabelLineHeightType,
 									letterSpacing: labelFont[ 0 ].letterSpacing + 'px',
 									textTransform: ( labelFont[ 0 ].textTransform ? labelFont[ 0 ].textTransform  : undefined ),
 									fontFamily: ( labelFont[ 0 ].family ? labelFont[ 0 ].family : undefined ),
@@ -3568,7 +3576,7 @@ class KadenceForm extends Component {
 								style={ {
 									background: ( undefined !== btnBG ? btnBG : undefined ),
 									color: ( undefined !== submit[ 0 ].color ? KadenceColorOutput( submit[ 0 ].color ) : undefined ),
-									fontSize: ( submitFont[ 0 ].size && submitFont[ 0 ].size[ 0 ] ? submitFont[ 0 ].size[ 0 ] + submitFont[ 0 ].sizeType : undefined ),
+									fontSize: previewSubmitFontSize + previewSubmitFontSizeType,
 									lineHeight: ( submitFont[ 0 ].lineHeight && submitFont[ 0 ].lineHeight[ 0 ] ? submitFont[ 0 ].lineHeight[ 0 ] + submitFont[ 0 ].lineType : undefined ),
 									fontWeight: submitFont[ 0 ].weight,
 									fontStyle: submitFont[ 0 ].style,

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -706,11 +706,19 @@ class KadenceForm extends Component {
 		const previewContainerMarginRight = getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 1 ] ? containerMargin[ 1 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 1 ] ? tabletContainerMargin[ 1 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 1 ] ? mobileContainerMargin[ 1 ] : '' ) );
 		const previewContainerMarginBottom = getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 2 ] ? containerMargin[ 2 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 2 ] ? tabletContainerMargin[ 2 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 2 ] ? mobileContainerMargin[ 2 ] : '' ) );
 		const previewContainerMarginLeft = getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 3 ] ? containerMargin[ 3 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 3 ] ? tabletContainerMargin[ 3 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 3 ] ? mobileContainerMargin[ 3 ] : '' ) );
+
+		const previewStyleFontSize = getPreviewSize( this.props.getPreviewDevice, style[ 0 ].fontSize[0], style[ 0 ].fontSize[1], style[ 0 ].fontSize[2] );
+		const previewStyleFontSizeType = style[ 0 ].fontSizeType;
+		const previewStyleLineHeight = getPreviewSize( this.props.getPreviewDevice, style[ 0 ].lineHeight[0], style[ 0 ].lineHeight[1], style[ 0 ].lineHeight[2] );
+		const previewStyleLineHeightType = style[ 0 ].lineType;
+
 		const previewRowGap = getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].rowGap && '' !== style[ 0 ].rowGap ? style[ 0 ].rowGap + 'px' : '' ), ( undefined !== style[ 0 ].tabletRowGap && '' !== style[ 0 ].tabletRowGap ? style[ 0 ].tabletRowGap + 'px' : '' ), ( undefined !== style[ 0 ].mobileRowGap && '' !== style[ 0 ].mobileRowGap ? style[ 0 ].mobileRowGap + 'px' : '' ) );
 		const previewGutter = getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].gutter && '' !== style[ 0 ].gutter ? style[ 0 ].gutter : '' ), ( undefined !== style[ 0 ].tabletGutter && '' !== style[ 0 ].tabletGutter ? style[ 0 ].tabletGutter : '' ), ( undefined !== style[ 0 ].mobileGutter && '' !== style[ 0 ].mobileGutter ? style[ 0 ].mobileGutter : '' ) );
 		const containerMarginMin = ( containerMarginType === 'em' || containerMarginType === 'rem' ? -2 : -200 );
 		const containerMarginMax = ( containerMarginType === 'em' || containerMarginType === 'rem' ? 12 : 200 );
 		const containerMarginStep = ( containerMarginType === 'em' || containerMarginType === 'rem' ? 0.1 : 1 );
+
+
 		const saveMailerlite = ( value ) => {
 			const newItems = mailerlite.map( ( item, thisIndex ) => {
 				if ( 0 === thisIndex ) {
@@ -1332,8 +1340,8 @@ class KadenceForm extends Component {
 									paddingLeft: ( 'custom' === style[ 0 ].size && '' !== style[ 0 ].deskPadding[ 3 ] ? style[ 0 ].deskPadding[ 3 ] + 'px' : undefined ),
 									background: ( undefined !== inputBG ? inputBG : undefined ),
 									color: ( undefined !== style[ 0 ].color ? KadenceColorOutput( style[ 0 ].color ) : undefined ),
-									fontSize: ( style[ 0 ].fontSize && style[ 0 ].fontSize[ 0 ] ? style[ 0 ].fontSize[ 0 ] + style[ 0 ].fontSizeType : undefined ),
-									lineHeight: ( style[ 0 ].lineHeight && style[ 0 ].lineHeight[ 0 ] ? style[ 0 ].lineHeight[ 0 ] + style[ 0 ].lineType : undefined ),
+									fontSize: previewStyleFontSize + previewStyleFontSizeType,
+									lineHeight: previewStyleLineHeight + previewStyleLineHeightType,
 									borderRadius: ( undefined !== style[ 0 ].borderRadius ? style[ 0 ].borderRadius + 'px' : undefined ),
 									borderTopWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 0 ] ? style[ 0 ].borderWidth[ 0 ] + 'px' : undefined ),
 									borderRightWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 1 ] ? style[ 0 ].borderWidth[ 1 ] + 'px' : undefined ),
@@ -1347,8 +1355,8 @@ class KadenceForm extends Component {
 								<select name={ `kb_field_${ index }` } id={ `kb_field_${ index }` } type={ fields[ index ].type } data-type={ fields[ index ].type } multiple={ ( fields[ index ].multiSelect ? true : false ) } className={ `kb-field kb-select-style-field kb-${ fields[ index ].type }-field kb-field-${ index }` } data-required={ ( fields[ index ].required ? 'yes' : undefined ) } style={ {
 									background: ( undefined !== inputBG ? inputBG : undefined ),
 									color: ( undefined !== style[ 0 ].color ? KadenceColorOutput( style[ 0 ].color ) : undefined ),
-									fontSize: ( style[ 0 ].fontSize && style[ 0 ].fontSize[ 0 ] ? style[ 0 ].fontSize[ 0 ] + style[ 0 ].fontSizeType : undefined ),
-									lineHeight: ( style[ 0 ].lineHeight && style[ 0 ].lineHeight[ 0 ] ? style[ 0 ].lineHeight[ 0 ] + style[ 0 ].lineType : undefined ),
+									fontSize: previewStyleFontSize + previewStyleFontSizeType,
+									lineHeight: previewStyleLineHeight + previewStyleLineHeightType,
 									borderRadius: ( undefined !== style[ 0 ].borderRadius ? style[ 0 ].borderRadius + 'px' : undefined ),
 									borderTopWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 0 ] ? style[ 0 ].borderWidth[ 0 ] + 'px' : undefined ),
 									borderRightWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 1 ] ? style[ 0 ].borderWidth[ 1 ] + 'px' : undefined ),
@@ -1418,8 +1426,8 @@ class KadenceForm extends Component {
 										paddingLeft: ( 'custom' === style[ 0 ].size && '' !== style[ 0 ].deskPadding[ 3 ] ? style[ 0 ].deskPadding[ 3 ] + 'px' : undefined ),
 										background: ( undefined !== inputBG ? inputBG : undefined ),
 										color: ( undefined !== style[ 0 ].color ? KadenceColorOutput( style[ 0 ].color ) : undefined ),
-										fontSize: ( style[ 0 ].fontSize && style[ 0 ].fontSize[ 0 ] ? style[ 0 ].fontSize[ 0 ] + style[ 0 ].fontSizeType : undefined ),
-										lineHeight: ( style[ 0 ].lineHeight && style[ 0 ].lineHeight[ 0 ] ? style[ 0 ].lineHeight[ 0 ] + style[ 0 ].lineType : undefined ),
+										fontSize: previewStyleFontSize + previewStyleFontSizeType,
+										lineHeight: previewStyleLineHeight + previewStyleLineHeightType,
 										borderRadius: ( undefined !== style[ 0 ].borderRadius ? style[ 0 ].borderRadius + 'px' : undefined ),
 										borderTopWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 0 ] ? style[ 0 ].borderWidth[ 0 ] + 'px' : undefined ),
 										borderRightWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 1 ] ? style[ 0 ].borderWidth[ 1 ] + 'px' : undefined ),
@@ -1449,8 +1457,8 @@ class KadenceForm extends Component {
 										paddingLeft: ( 'custom' === style[ 0 ].size && '' !== style[ 0 ].deskPadding[ 3 ] ? style[ 0 ].deskPadding[ 3 ] + 'px' : undefined ),
 										background: ( undefined !== inputBG ? inputBG : undefined ),
 										color: ( undefined !== style[ 0 ].color ? KadenceColorOutput( style[ 0 ].color ) : undefined ),
-										fontSize: ( style[ 0 ].fontSize && style[ 0 ].fontSize[ 0 ] ? style[ 0 ].fontSize[ 0 ] + style[ 0 ].fontSizeType : undefined ),
-										lineHeight: ( style[ 0 ].lineHeight && style[ 0 ].lineHeight[ 0 ] ? style[ 0 ].lineHeight[ 0 ] + style[ 0 ].lineType : undefined ),
+										fontSize: previewStyleFontSize + previewStyleFontSizeType,
+										lineHeight: previewStyleLineHeight + previewStyleLineHeightType,
 										borderRadius: ( undefined !== style[ 0 ].borderRadius ? style[ 0 ].borderRadius + 'px' : undefined ),
 										borderTopWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 0 ] ? style[ 0 ].borderWidth[ 0 ] + 'px' : undefined ),
 										borderRightWidth: ( style[ 0 ].borderWidth && '' !== style[ 0 ].borderWidth[ 1 ] ? style[ 0 ].borderWidth[ 1 ] + 'px' : undefined ),
@@ -1823,6 +1831,7 @@ class KadenceForm extends Component {
 							lineHeightType={ style[ 0 ].lineType }
 							onLineHeightType={ ( value ) => this.saveStyle( { lineType: value } ) }
 						/>
+
 						<div className="kt-btn-size-settings-container">
 							<h2 className="kt-beside-btn-group">{ __( 'Input Size' ) }</h2>
 							<ButtonGroup className="kt-button-size-type-options" aria-label={ __( 'Input Size', 'kadence-blocks' ) }>

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -27,6 +27,8 @@ import ResponsiveRangeControls from '../../components/range/responsive-range-con
 import URLInputControl from '../../components/links/link-control';
 import MailerLiteControls from './mailerlite.js';
 import FluentCRMControls from './fluentcrm.js';
+import { getPreviewSize } from '../../helpers/helpers';
+
 /**
  * Import Css
  */
@@ -695,30 +697,17 @@ class KadenceForm extends Component {
 			this.onOptionMove( oldIndex, oldIndex - 1, fieldIndex );
 		};
 	}
-	getPreviewSize( device, desktopSize, tabletSize, mobileSize ) {
-		if ( device === 'Mobile' ) {
-			if ( undefined !== mobileSize && '' !== mobileSize ) {
-				return mobileSize;
-			} else if ( undefined !== tabletSize && '' !== tabletSize ) {
-				return tabletSize;
-			}
-		} else if ( device === 'Tablet' ) {
-			if ( undefined !== tabletSize && '' !== tabletSize ) {
-				return tabletSize;
-			}
-		}
-		return desktopSize;
-	}
+
 	render() {
 		const { attributes: { uniqueID, style, fields, submit, actions, align, labelFont, recaptcha, redirect, messages, messageFont, email, hAlign, honeyPot, submitFont, kadenceAnimation, kadenceAOSOptions, submitMargin, recaptchaVersion, mailerlite, fluentcrm, containerMargin, tabletContainerMargin, mobileContainerMargin, containerMarginType, submitLabel }, className, isSelected, setAttributes } = this.props;
 		const { deskPaddingControl, tabletPaddingControl, mobilePaddingControl, borderControl, labelPaddingControl, labelMarginControl, submitDeskPaddingControl, submitTabletPaddingControl, submitMobilePaddingControl, submitBorderControl, messageFontBorderControl, messagePaddingControl, messageMarginControl, deskMarginControl, tabletMarginControl, mobileMarginControl } = this.state;
 		const previewContainerMarginType = ( undefined !== containerMarginType ? containerMarginType : 'px' );
-		const previewContainerMarginTop = this.getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 0 ] ? containerMargin[ 0 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 0 ] ? tabletContainerMargin[ 0 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 0 ] ? mobileContainerMargin[ 0 ] : '' ) );
-		const previewContainerMarginRight = this.getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 1 ] ? containerMargin[ 1 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 1 ] ? tabletContainerMargin[ 1 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 1 ] ? mobileContainerMargin[ 1 ] : '' ) );
-		const previewContainerMarginBottom = this.getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 2 ] ? containerMargin[ 2 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 2 ] ? tabletContainerMargin[ 2 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 2 ] ? mobileContainerMargin[ 2 ] : '' ) );
-		const previewContainerMarginLeft = this.getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 3 ] ? containerMargin[ 3 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 3 ] ? tabletContainerMargin[ 3 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 3 ] ? mobileContainerMargin[ 3 ] : '' ) );
-		const previewRowGap = this.getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].rowGap && '' !== style[ 0 ].rowGap ? style[ 0 ].rowGap + 'px' : '' ), ( undefined !== style[ 0 ].tabletRowGap && '' !== style[ 0 ].tabletRowGap ? style[ 0 ].tabletRowGap + 'px' : '' ), ( undefined !== style[ 0 ].mobileRowGap && '' !== style[ 0 ].mobileRowGap ? style[ 0 ].mobileRowGap + 'px' : '' ) );
-		const previewGutter = this.getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].gutter && '' !== style[ 0 ].gutter ? style[ 0 ].gutter : '' ), ( undefined !== style[ 0 ].tabletGutter && '' !== style[ 0 ].tabletGutter ? style[ 0 ].tabletGutter : '' ), ( undefined !== style[ 0 ].mobileGutter && '' !== style[ 0 ].mobileGutter ? style[ 0 ].mobileGutter : '' ) );
+		const previewContainerMarginTop = getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 0 ] ? containerMargin[ 0 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 0 ] ? tabletContainerMargin[ 0 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 0 ] ? mobileContainerMargin[ 0 ] : '' ) );
+		const previewContainerMarginRight = getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 1 ] ? containerMargin[ 1 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 1 ] ? tabletContainerMargin[ 1 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 1 ] ? mobileContainerMargin[ 1 ] : '' ) );
+		const previewContainerMarginBottom = getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 2 ] ? containerMargin[ 2 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 2 ] ? tabletContainerMargin[ 2 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 2 ] ? mobileContainerMargin[ 2 ] : '' ) );
+		const previewContainerMarginLeft = getPreviewSize( this.props.getPreviewDevice, ( undefined !== containerMargin && undefined !== containerMargin[ 3 ] ? containerMargin[ 3 ] : '' ), ( undefined !== tabletContainerMargin && undefined !== tabletContainerMargin[ 3 ] ? tabletContainerMargin[ 3 ] : '' ), ( undefined !== mobileContainerMargin && undefined !== mobileContainerMargin[ 3 ] ? mobileContainerMargin[ 3 ] : '' ) );
+		const previewRowGap = getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].rowGap && '' !== style[ 0 ].rowGap ? style[ 0 ].rowGap + 'px' : '' ), ( undefined !== style[ 0 ].tabletRowGap && '' !== style[ 0 ].tabletRowGap ? style[ 0 ].tabletRowGap + 'px' : '' ), ( undefined !== style[ 0 ].mobileRowGap && '' !== style[ 0 ].mobileRowGap ? style[ 0 ].mobileRowGap + 'px' : '' ) );
+		const previewGutter = getPreviewSize( this.props.getPreviewDevice, ( undefined !== style[ 0 ].gutter && '' !== style[ 0 ].gutter ? style[ 0 ].gutter : '' ), ( undefined !== style[ 0 ].tabletGutter && '' !== style[ 0 ].tabletGutter ? style[ 0 ].tabletGutter : '' ), ( undefined !== style[ 0 ].mobileGutter && '' !== style[ 0 ].mobileGutter ? style[ 0 ].mobileGutter : '' ) );
 		const containerMarginMin = ( containerMarginType === 'em' || containerMarginType === 'rem' ? -2 : -200 );
 		const containerMarginMax = ( containerMarginType === 'em' || containerMarginType === 'rem' ? 12 : 200 );
 		const containerMarginStep = ( containerMarginType === 'em' || containerMarginType === 'rem' ? 0.1 : 1 );
@@ -945,7 +934,7 @@ class KadenceForm extends Component {
 							<Fragment>
 								{ times( fields[ index ].options.length, n => (
 									<div className="field-options-wrap">
-										
+
 										<TextControl
 											className={ 'kb-option-text-control' }
 											key={ n }

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -1,0 +1,21 @@
+/**
+ * Helper functions
+ */
+
+/**
+ * Return the proper preview size, given the current preview device
+ */
+export function getPreviewSize( device, desktopSize, tabletSize, mobileSize ) {
+	if ( device === 'Mobile' ) {
+		if ( undefined !== mobileSize && '' !== mobileSize && null !== mobileSize ) {
+			return mobileSize;
+		} else if ( undefined !== tabletSize && '' !== tabletSize && null !== tabletSize ) {
+			return tabletSize;
+		}
+	} else if ( device === 'Tablet' ) {
+		if ( undefined !== tabletSize && '' !== tabletSize && null !== tabletSize ) {
+			return tabletSize;
+		}
+	}
+	return desktopSize;
+}


### PR DESCRIPTION
Any objections to moving `getPreviewSize` function to its own helper file? I've implemented it in this PR

[src/helpers/helpers.js](https://github.com/oakesjosh/kadence-blocks/blob/fc8163d854251f0425c96a1119c5f45a9e6c6d20/src/helpers/helpers.js)

This PR fixes responsive previews for 
- label font size
- label line height
- style font size
- style line height
- submit font size
- submit line height