### PR TITLE
Fix KadencePanelBody error on advanced button

### DIFF
--- a/src/blocks/advanced-btn/edit.js
+++ b/src/blocks/advanced-btn/edit.js
@@ -1720,7 +1720,7 @@ class KadenceAdvancedButton extends Component {
 									<KadencePanelBody
 										title={ __( 'Button Count', 'kadence-blocks' ) }
 										initialOpen={ true }
-										panelName={ 'kb-adv-btn-count-' + index }
+										panelName={ 'kb-adv-btn-count' }
 									>
 										{ ! lockBtnCount && (
 										<PanelRow>


### PR DESCRIPTION
This panel shouldn't have had an index appended to its key