### PR TITLE
Feature/accordion editor updates

### DIFF
--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -65,7 +65,6 @@ import {
 import {
 	useEffect,
 	useState,
-	Fragment,
 } from '@wordpress/element';
 import {
 	InspectorControls,
@@ -87,6 +86,8 @@ import {
 import { withSelect, withDispatch, useSelect, useDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
+import { plus, reset } from '@wordpress/icons';
+
 /**
  * Internal block libraries
  */
@@ -107,7 +108,7 @@ const getPanesTemplate = memoize( ( panes ) => {
 /**
  * Build the row edit
  */
-function KadenceAccordionComponent( { attributes, className, setAttributes, clientId, realPaneCount, accordionBlock, removePane, updatePaneTag, updateFaqSchema, insertPane, getPreviewDevice } ) {
+function KadenceAccordionComponent( { attributes, className, setAttributes, clientId, realPaneCount, isSelected, accordionBlock, removePane, updatePaneTag, updateFaqSchema, insertPane, getPreviewDevice } ) {
 	const {
 		uniqueID,
 		paneCount,
@@ -834,15 +835,15 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 					${ ! previewTitleBorderHoverLeft && previewTitleBorderColorHoverLeft ? 'border-left-color:' + previewTitleBorderColorHoverLeft : '' };
 					${titleStyles?.[ 0 ]?.backgroundHover ? 'background-color:' + KadenceColorOutput( titleStyles[ 0 ].backgroundHover ) : '' };
 				}
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, 
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-accordion-pane:not(.kt-accordion-panel-active) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-accordion-pane:not(.kt-accordion-panel-active) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${ '' !== iconColor.hover ? KadenceColorOutput(iconColor.hover) : KadenceColorOutput( titleStyles[ 0 ].colorHover )};
 				}
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, 
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-pane:not(.kt-accordion-panel-active) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-pane:not(.kt-accordion-panel-active) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${ '' !== iconColor.hover ? KadenceColorOutput(iconColor.hover) : KadenceColorOutput( titleStyles[ 0 ].backgroundHover )};
 				}
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-pane:not(.kt-accordion-panel-active) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger {
 					background-color: ${ '' !== iconColor.hover ? KadenceColorOutput(iconColor.hover) : KadenceColorOutput( titleStyles[ 0 ].colorHover )};
 				}
 				.kt-accordion-${uniqueID} .kt-accordion-panel-active .kt-blocks-accordion-header {
@@ -923,7 +924,7 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 						<>
 							<KadencePanelBody panelName={'kb-accordion-all'}>
 								{ showSettings( 'paneControl', 'kadence/accordion' ) && (
-									<Fragment>
+									<>
 										<ToggleControl
 											label={__( 'Panes close when another opens', 'kadence-blocks' )}
 											checked={linkPaneCollapse}
@@ -935,11 +936,11 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 											onChange={( value ) => setAttributes( { startCollapsed: value } )}
 										/>
 										{!startCollapsed && (
-											<Fragment>
+											<>
 												<h2>{__( 'Initial Open Accordion', 'kadence-blocks' )}</h2>
 												<ButtonGroup aria-label={__( 'Initial Open Accordion', 'kadence-blocks' )}>
 													{accordionBlock && accordionBlock[ 0 ] && accordionBlock[ 0 ].innerBlocks && (
-														<Fragment>
+														<>
 															{map( accordionBlock[ 0 ].innerBlocks, ( { attributes } ) => (
 																<Button
 																	key={attributes.id - 1}
@@ -952,10 +953,10 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 																	{__( 'Accordion Pane', 'kadence-blocks' ) + ' ' + ( attributes.id )}
 																</Button>
 															) )}
-														</Fragment>
+														</>
 													)}
 													{accordionBlock && accordionBlock.innerBlocks && (
-														<Fragment>
+														<>
 															{map( accordionBlock.innerBlocks, ( { attributes } ) => (
 																<Button
 																	key={attributes.id - 1}
@@ -968,12 +969,12 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 																	{__( 'Accordion Pane', 'kadence-blocks' ) + ' ' + ( attributes.id )}
 																</Button>
 															) )}
-														</Fragment>
+														</>
 													)}
 												</ButtonGroup>
-											</Fragment>
+											</>
 										)}
-									</Fragment>
+									</>
 								)}
 							</KadencePanelBody>
 							{ showSettings( 'titleIcon', 'kadence/accordion' ) && (
@@ -1510,7 +1511,7 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 					</div>
 				)}
 				{ ! showPreset && (
-					<Fragment>
+					<>
 						<div className="kt-accordion-selecter">{__( 'Accordion', 'kadence-blocks' )}</div>
 						<div className="kt-accordion-wrap" style={ {
 							maxWidth: maxWidth + 'px',
@@ -1520,34 +1521,36 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 							) }
 							<div { ...innerBlocksProps } />
 						</div>
-						<div className="kt-accordion-add-selecter">
-							<Button
-								className="kt-accordion-add"
-								isPrimary={ true }
-								icon="plus"
-								iconPosition="left"
-								iconSize={ 16 }
-								onClick={ () => {
-									const newBlock = createBlock( 'kadence/pane', { id: paneCount + 1, titleTag: titleTag } );
-									setAttributes( { paneCount: paneCount + 1 } );
-									insertPane( newBlock );
-								}}
-							>
-								{ __( 'Add Accordion Item', 'kadence-blocks' ) }
-							</Button>
-							{ realPaneCount > 1 && (
+						{ isSelected && (
+							<div className="kt-accordion-add-selecter">
 								<Button
-									className="kt-accordion-remove"
-									label={__( 'Remove Accordion Item', 'kadence-blocks' )}
-									icon="minus"
-									onClick={() => {
-										const removeClientId = ( accordionBlock[ 0 ] ? accordionBlock[ 0 ].innerBlocks[ realPaneCount - 1 ].clientId : accordionBlock.innerBlocks[ realPaneCount - 1 ].clientId );
-										removePane( removeClientId );
+									className="kt-accordion-add"
+									variant="primary"
+									icon={ plus }
+									iconPosition="left"
+									iconSize={ 16 }
+									onClick={ () => {
+										const newBlock = createBlock( 'kadence/pane', { id: paneCount + 1, titleTag: titleTag } );
+										setAttributes( { paneCount: paneCount + 1 } );
+										insertPane( newBlock );
 									}}
-								/>
-							)}
-						</div>
-					</Fragment>
+								>
+									{ __( 'Add Accordion Item', 'kadence-blocks' ) }
+								</Button>
+								{ realPaneCount > 1 && (
+									<Button
+										className="kt-accordion-remove"
+										label={__( 'Remove Accordion Item', 'kadence-blocks' )}
+										icon={ reset }
+										onClick={() => {
+											const removeClientId = ( accordionBlock[ 0 ] ? accordionBlock[ 0 ].innerBlocks[ realPaneCount - 1 ].clientId : accordionBlock.innerBlocks[ realPaneCount - 1 ].clientId );
+											removePane( removeClientId );
+										}}
+									/>
+								)}
+							</div>
+						) }
+					</>
 				)}
 			</div>
 		</div>

--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -808,10 +808,15 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 					${previewContentRadiusLeft ? 'border-bottom-left-radius:' + previewContentRadiusLeft + contentBorderRadiusUnit : '' };
 					min-height:${( minHeight ? minHeight + 'px' : '0' )};
 				}
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID} .kt-accordion-panel-inner p:last-of-type{
+					margin-bottom: 0;
+				}
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${ '' !== iconColor.standard ? KadenceColorOutput( iconColor.standard ) : KadenceColorOutput( titleStyles[ 0 ].color )};
 				}
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, .kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${KadenceColorOutput( titleStyles[ 0 ].background )};
 				}
 				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header .kt-blocks-accordion-icon-trigger {
@@ -829,16 +834,18 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 					${ ! previewTitleBorderHoverLeft && previewTitleBorderColorHoverLeft ? 'border-left-color:' + previewTitleBorderColorHoverLeft : '' };
 					${titleStyles?.[ 0 ]?.backgroundHover ? 'background-color:' + KadenceColorOutput( titleStyles[ 0 ].backgroundHover ) : '' };
 				}
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, .kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${ '' !== iconColor.hover ? KadenceColorOutput(iconColor.hover) : KadenceColorOutput( titleStyles[ 0 ].colorHover )};
 				}
-				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, .kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${ '' !== iconColor.hover ? KadenceColorOutput(iconColor.hover) : KadenceColorOutput( titleStyles[ 0 ].backgroundHover )};
 				}
 				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-blocks-accordion-header:hover .kt-blocks-accordion-icon-trigger {
 					background-color: ${ '' !== iconColor.hover ? KadenceColorOutput(iconColor.hover) : KadenceColorOutput( titleStyles[ 0 ].colorHover )};
 				}
-				.kt-accordion-${uniqueID}.kt-start-active-pane-${openPane + 1} .kt-accordion-pane-${openPane + 1} .kt-blocks-accordion-header {
+				.kt-accordion-${uniqueID} .kt-accordion-panel-active .kt-blocks-accordion-header {
 					${titleStyles?.[ 0 ]?.colorActive ? 'color:' + KadenceColorOutput( titleStyles[ 0 ].colorActive ) : '' };
 					${previewTitleBorderActiveTop ? 'border-top:' + previewTitleBorderActiveTop : '' };
 					${previewTitleBorderActiveRight ? 'border-right:' + previewTitleBorderActiveRight : '' };
@@ -850,13 +857,15 @@ function KadenceAccordionComponent( { attributes, className, setAttributes, clie
 					${ ! previewTitleBorderActiveLeft && previewTitleBorderColorActiveLeft ? 'border-left-color:' + previewTitleBorderColorActiveLeft : '' };
 					${titleStyles?.[ 0 ]?.backgroundActive ? 'background-color:' + KadenceColorOutput( titleStyles[ 0 ].backgroundActive ) : '' };
 				}
-				.kt-accordion-${uniqueID}.kt-start-active-pane-${openPane + 1}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-accordion-pane-${openPane + 1} .kt-blocks-accordion-icon-trigger:before, .kt-accordion-${uniqueID}.kt-start-active-pane-${openPane + 1}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-accordion-pane-${openPane + 1} .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basiccircle ):not( .kt-accodion-icon-style-xclosecircle ):not( .kt-accodion-icon-style-arrowcircle ) .kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${ '' !== iconColor.active ? KadenceColorOutput(iconColor.active) : KadenceColorOutput( titleStyles[ 0 ].colorActive )};
 				}
-				.kt-accordion-${uniqueID}.kt-start-active-pane-${openPane + 1}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-pane-${openPane + 1} .kt-blocks-accordion-icon-trigger:before, .kt-accordion-${uniqueID}.kt-start-active-pane-${openPane + 1}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-pane-${openPane + 1} .kt-blocks-accordion-icon-trigger:after {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:before, 
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-panel-active .kt-blocks-accordion-icon-trigger:after {
 					background-color: ${KadenceColorOutput( titleStyles[ 0 ].backgroundActive )};
 				}
-				.kt-accordion-${uniqueID}.kt-start-active-pane-${openPane + 1}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-pane-${openPane + 1} .kt-blocks-accordion-icon-trigger {
+				.kt-accordion-${uniqueID}:not( .kt-accodion-icon-style-basic ):not( .kt-accodion-icon-style-xclose ):not( .kt-accodion-icon-style-arrow ) .kt-accordion-panel-active .kt-blocks-accordion-icon-trigger {
 					background-color: ${KadenceColorOutput( titleStyles[ 0 ].colorActive )};
 				}
 				`}

--- a/src/blocks/accordion/editor.scss
+++ b/src/blocks/accordion/editor.scss
@@ -156,13 +156,6 @@ button.components-button.kt-accordion-add.is-primary {
     box-shadow: none;
 	padding: 6px 10px;
 	border-radius: 3px;
-	.dashicon {
-		margin-right: 6px;
-		font-size: 16px;
-		margin-left: 0;
-		width: 16px;
-		height: 16px;
-	}
 }
 .kt-accordion-add-selecter button.components-button.kt-accordion-remove {
     border: 0;
@@ -177,9 +170,6 @@ button.components-button.kt-accordion-add.is-primary {
 .kt-accordion-add-selecter button.components-button.kt-accordion-remove:not(:disabled):not([aria-disabled=true]):not(.is-default):hover {
 	background: #eee;
 	box-shadow: none;
-}
-button.components-button.kt-accordion-add.is-primary svg {
-    margin-top: 4px;
 }
 .components-button-group button.components-button.kt-init-open-pane {
     width: 100%;

--- a/src/blocks/accordion/editor.scss
+++ b/src/blocks/accordion/editor.scss
@@ -126,12 +126,21 @@ body.rtl .kt-size-tabs .components-tab-panel__tabs, body.rtl .components-button-
 		}
 	}
 }
-.kt-accordion-panel-active .kt-blocks-accordion-header {
-	background-color: var(--global-palette5, #444444 );
-	color: #ffffff;
-	.kt-blocks-accordion-icon-trigger:after, .kt-blocks-accordion-icon-trigger:before {
-		background-color: currentColor;
+.kt-accordion-panel-active {
+	.kt-blocks-accordion-header {
+		background-color: var(--global-palette5, #444444 );
+		color: #ffffff;
+		.kt-blocks-accordion-icon-trigger:after, .kt-blocks-accordion-icon-trigger:before {
+			background-color: currentColor;
+		}
 	}
+
+	.kt-accordion-panel {
+		display: block;
+	}
+}
+.kt-accordion-panel {
+	display: none;
 }
 .kt-accordion-panel-inner {
     padding: 20px;

--- a/src/blocks/accordion/pane/edit.js
+++ b/src/blocks/accordion/pane/edit.js
@@ -62,6 +62,9 @@ function PaneEdit( {
 		},
 		[ clientId ]
 	);
+	const isStartCollapsed = undefined !== accordionBlock?.[0]?.attributes?.startCollapsed && accordionBlock[0].attributes.startCollapsed;
+	const isOpenPane = !isStartCollapsed && undefined !== accordionBlock?.[0]?.attributes?.openPane && ( accordionBlock[0].attributes.openPane + 1 === id )
+	setAttributes( { isPaneActive: attributes.isPaneActive ?? isOpenPane } );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const updatePaneCount = ( value ) => {
 		updateBlockAttributes( rootID, { paneCount: value } );
@@ -95,10 +98,10 @@ function PaneEdit( {
 		}
 	}, [] );
 	const blockClasses = classnames( {
-		'kt-accordion-pane'                   : true,
-		[ `kt-accordion-pane-${id}` ]  : id,
-		[ `kt-pane${uniqueID}` ]  : uniqueID,
-		[ `kt-accordion-panel-active` ]         : undefined !== accordionBlock?.[0]?.attributes?.openPane && ( accordionBlock[0].attributes.openPane + 1 === id ),
+		'kt-accordion-pane'             : true,
+		[ `kt-accordion-pane-${id}` ]   : id,
+		[ `kt-pane${uniqueID}` ]        : uniqueID,
+		[ `kt-accordion-panel-active` ] : attributes.isPaneActive,
 	} );
 	const blockProps = useBlockProps( {
 		className: blockClasses
@@ -146,7 +149,12 @@ function PaneEdit( {
 				</KadencePanelBody>
 			</InspectorControls>
 			<HtmlTagOut className={ `kt-accordion-header-wrap` } >
-				<div className={ `kt-blocks-accordion-header kt-acccordion-button-label-${ ( hideLabel ? 'hide' : 'show' ) }` }>
+				<div 
+					className={ `kt-blocks-accordion-header kt-acccordion-button-label-${ ( hideLabel ? 'hide' : 'show' ) }` }
+					onClick={() => {
+						setAttributes( { isPaneActive: !attributes.isPaneActive } );
+					}}
+				>
 					<div className="kt-blocks-accordion-title-wrap">
 						{ icon && 'left' === iconSide && (
 							<IconRender className={ `kt-btn-svg-icon kt-btn-svg-icon-${ icon } kt-btn-side-${ iconSide }` } name={ icon } />

--- a/src/blocks/accordion/pane/edit.js
+++ b/src/blocks/accordion/pane/edit.js
@@ -62,9 +62,20 @@ function PaneEdit( {
 		},
 		[ clientId ]
 	);
+	const { hasInnerBlocks } = useSelect(
+		( select ) => {
+			const { getBlock } = select( blockEditorStore );
+			const block = getBlock( clientId );
+			return {
+				hasInnerBlocks: !! ( block && block.innerBlocks.length ),
+			};
+		},
+		[ clientId ]
+	);
 	const isStartCollapsed = undefined !== accordionBlock?.[0]?.attributes?.startCollapsed && accordionBlock[0].attributes.startCollapsed;
 	const isOpenPane = !isStartCollapsed && undefined !== accordionBlock?.[0]?.attributes?.openPane && ( accordionBlock[0].attributes.openPane + 1 === id )
-	setAttributes( { isPaneActive: attributes.isPaneActive ?? isOpenPane } );
+	const isNewPane = !uniqueID;
+	setAttributes( { isPaneActive: attributes.isPaneActive ?? isNewPane ? true : isOpenPane } );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const updatePaneCount = ( value ) => {
 		updateBlockAttributes( rootID, { paneCount: value } );
@@ -112,6 +123,9 @@ function PaneEdit( {
 		},
 		{
 			templateLock: false,
+			renderAppender: hasInnerBlocks
+				? undefined
+				: InnerBlocks.ButtonBlockAppender,
 		}
 	);
 	return (

--- a/src/blocks/accordion/pane/edit.js
+++ b/src/blocks/accordion/pane/edit.js
@@ -174,9 +174,7 @@ function PaneEdit( {
 							<IconRender className={ `kt-btn-svg-icon kt-btn-svg-icon-${ icon } kt-btn-side-${ iconSide }` } name={ icon } />
 						) }
 					</div>
-					<div 
-						className="kt-blocks-accordion-icon-trigger"
-					></div>
+					<div className="kt-blocks-accordion-icon-trigger"></div>
 				</div>
 			</HtmlTagOut>
 			<div className={ 'kt-accordion-panel' } >

--- a/src/blocks/accordion/pane/edit.js
+++ b/src/blocks/accordion/pane/edit.js
@@ -153,7 +153,7 @@ function PaneEdit( {
 					className={ `kt-blocks-accordion-header kt-acccordion-button-label-${ ( hideLabel ? 'hide' : 'show' ) }` }
 					onClick={() => {
 						setAttributes( { isPaneActive: !attributes.isPaneActive } );
-					}}
+					}} 
 				>
 					<div className="kt-blocks-accordion-title-wrap">
 						{ icon && 'left' === iconSide && (
@@ -166,12 +166,17 @@ function PaneEdit( {
 							onChange={ value => setAttributes( { title: value } ) }
 							value={ title }
 							keepPlaceholderOnFocus
+							onClick={(e) => {
+								e.stopPropagation();
+							}}
 						/>
 						{ icon && 'right' === iconSide && (
 							<IconRender className={ `kt-btn-svg-icon kt-btn-svg-icon-${ icon } kt-btn-side-${ iconSide }` } name={ icon } />
 						) }
 					</div>
-					<div className="kt-blocks-accordion-icon-trigger"></div>
+					<div 
+						className="kt-blocks-accordion-icon-trigger"
+					></div>
 				</div>
 			</HtmlTagOut>
 			<div className={ 'kt-accordion-panel' } >


### PR DESCRIPTION
Made accordion open/close work in the editor
They open unless you've specifically clicked the title rickText element
Supports the "Start with all panes collapsed" setting
Intentionally does not support the "Panes close when another opens" setting. To avoid a cumbersome editing experience.
Includes using the button renderAppender for empty accordions
New accordion panes begin as active
